### PR TITLE
Remove flutter_widgets' dependency on package:intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.6-dev.2
+
+* Removed dependency on package:intl.
+
 # 0.1.6-dev.1
 
 * Added `ScrollablePositionedList`.

--- a/gallery/pubspec.yaml
+++ b/gallery/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   flutter_widgets:
     path: ../
-  intl: ^0.16.0
   meta: ^1.1.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flutter_widgets
-version: 0.1.6-dev.1
+version: 0.1.6-dev.2
 description: >
   Flutter widgets that are developed by Google but not by the core
   Flutter team.
 authors:
-  - djshuckerow@google.com
-  - anthony.bullard@gmail.com
-  - jamesdlin@google.com
-  - robinsontom@google.com
+  - Dave Shuckerhow <djshuckerow@google.com>
+  - Anthony Bullard <anthony.bullard@gmail.com>
+  - James Lin <jamesdlin@google.com>
+  - Tom Robinson <robinsontom@google.com>
 homepage: https://github.com/google/flutter.widgets
 
 environment:
@@ -19,7 +19,6 @@ dependencies:
   flutter:
     sdk: flutter
   html: ^0.14.0
-  intl: ^0.16.0
   meta: ^1.1.1
   quiver: ^2.0.0+1
 


### PR DESCRIPTION
No externally published widgets from flutter_widgets actually depend
on package:intl, so remove the dependency.  This avoids a version
mismatch between flutter's master branch and fluter's dev branch.

While I'm touching this, also adjust the format for the authors so
that pub stops complaining about it.

Fixes https://github.com/google/flutter.widgets/issues/25.

PiperOrigin-RevId: 268025975