### PR TITLE
POC: Feature discovery for any widget

### DIFF
--- a/lib/src/feature_discovery/src/feature_discovery_widget.dart
+++ b/lib/src/feature_discovery/src/feature_discovery_widget.dart
@@ -86,7 +86,7 @@ class FeatureDiscovery extends StatefulWidget {
   final String description;
 
   /// Icon to be promoted.
-  final Icon child;
+  final Widget child;
 
   /// Flag to indicate whether to show the overlay or not anchored to the
   /// [child].


### PR DESCRIPTION
## Description

This is an attempt to add support discovery for any widget.

Instead of painting a circle with a solid color, a ring with transparent
inner part is painted. The inner part has also offset to align with the
child widget and the Ripple effect. This way overlay can be pointed to
any widget.

There are still some limitations. When TextInput is provided as a
child, transparent circle will centered, instead of showing the part
which has cursor. Also internal circle width cannot be changed.

I'm mostly concerned if I'm going in the right direction or this is
completely flawed approach.

![Screenshot_1582581589](https://user-images.githubusercontent.com/127442/75195036-1be23b00-5751-11ea-838b-5d38c660b6c0.png)
![Screenshot_1582581613](https://user-images.githubusercontent.com/127442/75195051-21d81c00-5751-11ea-9010-7f0ebff0b816.png)

## Related Issues

#65 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
