### PR TITLE
When itemCount is zero it executes builder with index 0

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -200,7 +200,7 @@ class _PositionedListState extends State<PositionedList> {
                       ? _buildItem(index + widget.positionedIndex)
                       : _buildSeparatedListElement(
                           index + 2 * widget.positionedIndex),
-                  childCount: 1,
+                  childCount: widget.itemCount != 0 ? 1 : 0,
                   addSemanticIndexes: false,
                   addRepaintBoundaries: widget.addRepaintBoundaries,
                   addAutomaticKeepAlives: widget.addAutomaticKeepAlives,

--- a/packages/scrollable_positioned_list/test/separated_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/separated_positioned_list_test.dart
@@ -50,6 +50,13 @@ void main() {
     );
   }
 
+  testWidgets('Empty list', (WidgetTester tester) async {
+    await setUpWidgetTest(tester, itemCount: 0);
+
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Separator 0'), findsNothing);
+  });
+
   testWidgets('Short list', (WidgetTester tester) async {
     await setUpWidgetTest(tester, itemCount: 3);
 


### PR DESCRIPTION
## Description

When `itemCount` is zero it executes builder with index 0 which is slightly wrong cause there is no items) This PR fixes that unexpected behaviour and adds test for an empty list.

## Related Issues

#78

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
