### PR TITLE
[ScrollablePositionedList] itemBuilders should not be called with indices > itemCount - 1.

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -208,7 +208,8 @@ class _PositionedListState extends State<PositionedList> {
                 ),
               ),
             ),
-            if (widget.positionedIndex < widget.itemCount - 1)
+            if (widget.positionedIndex >= 0 &&
+                widget.positionedIndex < widget.itemCount - 1)
               SliverPadding(
                 padding: _trailingSliverPadding,
                 sliver: SliverList(

--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -44,7 +44,8 @@ class PositionedList extends StatefulWidget {
     this.addRepaintBoundaries = true,
     this.addAutomaticKeepAlives = true,
   })  : assert(itemCount != null),
-        assert(itemBuilder != null);
+        assert(itemBuilder != null),
+        assert((positionedIndex == 0) || (positionedIndex < itemCount));
 
   /// Number of items the [itemBuilder] can produce.
   final int itemCount;

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -222,6 +222,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontTarget = initialPosition?.index ?? widget.initialScrollIndex;
     frontAlignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
+    if (widget.itemCount != null && frontTarget > widget.itemCount - 1) {
+      frontTarget = widget.itemCount - 1;
+    }
     widget.itemScrollController?._attach(this);
     frontItemPositionNotifier.itemPositions.addListener(_updatePositions);
     backItemPositionNotifier.itemPositions.addListener(_updatePositions);
@@ -233,6 +236,19 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontItemPositionNotifier.itemPositions.removeListener(_updatePositions);
     backItemPositionNotifier.itemPositions.removeListener(_updatePositions);
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(ScrollablePositionedList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.itemCount != null) {
+      if (frontTarget > widget.itemCount - 1) {
+        frontTarget = widget.itemCount - 1;
+      }
+      if (backTarget > widget.itemCount - 1) {
+        backTarget = widget.itemCount - 1;
+      }
+    }
   }
 
   @override

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -323,6 +323,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
 
   void _jumpTo({@required int index, double alignment}) {
     cancelScrollCallback?.call();
+    if (index > widget.itemCount - 1) {
+      index = widget.itemCount - 1;
+    }
     if (_showFrontList) {
       frontScrollController.jumpTo(0);
       setState(() {
@@ -343,6 +346,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
       double alignment,
       @required Duration duration,
       Curve curve = Curves.linear}) async {
+    if (index > widget.itemCount - 1) {
+      index = widget.itemCount - 1;
+    }
     if (cancelScrollCallback != null) {
       cancelScrollCallback();
       SchedulerBinding.instance.addPostFrameCallback((_) {

--- a/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
@@ -37,17 +37,21 @@ void main() {
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     tester.binding.window.physicalSizeTestValue =
         const Size(screenWidth, screenHeight);
+    itemCount = itemCount ?? defaultItemCount;
 
     await tester.pumpWidget(
       MaterialApp(
         home: ScrollablePositionedList.builder(
           key: key,
-          itemCount: itemCount ?? defaultItemCount,
+          itemCount: itemCount,
           itemScrollController: itemScrollController,
-          itemBuilder: (context, index) => SizedBox(
-            height: itemHeight,
-            child: Text('Item $index'),
-          ),
+          itemBuilder: (context, index) {
+            assert(index <= itemCount - 1);
+            return SizedBox(
+              height: itemHeight,
+              child: Text('Item $index'),
+            );
+          },
           itemPositionsListener: itemPositionsListener,
           initialScrollIndex: initialIndex,
           initialAlignment: initialAlignment,
@@ -1329,10 +1333,10 @@ void main() {
     final itemScrollController = ItemScrollController();
     await setUpWidgetTest(tester, itemScrollController: itemScrollController);
 
-    itemScrollController.jumpTo(index: defaultItemCount);
+    itemScrollController.jumpTo(index: defaultItemCount - 1);
     await tester.pumpAndSettle();
 
-    expect(tester.getBottomLeft(find.text('Item $defaultItemCount')).dy,
+    expect(tester.getBottomLeft(find.text('Item ${defaultItemCount - 1}')).dy,
         screenHeight);
   });
 
@@ -1341,10 +1345,10 @@ void main() {
     await setUpWidgetTest(tester, itemScrollController: itemScrollController);
 
     unawaited(itemScrollController.scrollTo(
-        index: defaultItemCount, duration: scrollDuration));
+        index: defaultItemCount - 1, duration: scrollDuration));
     await tester.pumpAndSettle();
 
-    expect(tester.getBottomLeft(find.text('Item $defaultItemCount')).dy,
+    expect(tester.getBottomLeft(find.text('Item ${defaultItemCount - 1}')).dy,
         screenHeight);
   });
 
@@ -1354,14 +1358,14 @@ void main() {
     await setUpWidgetTest(tester, itemScrollController: itemScrollController);
 
     unawaited(itemScrollController.scrollTo(
-        index: defaultItemCount, duration: scrollDuration));
+        index: defaultItemCount - 1, duration: scrollDuration));
     await tester.pumpAndSettle();
     itemScrollController.jumpTo(index: 0);
     await tester.pumpAndSettle();
     itemScrollController.jumpTo(index: defaultItemCount);
     await tester.pumpAndSettle();
 
-    expect(tester.getBottomLeft(find.text('Item $defaultItemCount')).dy,
+    expect(tester.getBottomLeft(find.text('Item ${defaultItemCount - 1}')).dy,
         screenHeight);
   });
 
@@ -1370,17 +1374,17 @@ void main() {
     final itemScrollController = ItemScrollController();
     await setUpWidgetTest(tester, itemScrollController: itemScrollController);
 
-    itemScrollController.jumpTo(index: defaultItemCount);
+    itemScrollController.jumpTo(index: defaultItemCount - 1);
     await tester.pumpAndSettle();
 
     unawaited(
         itemScrollController.scrollTo(index: 0, duration: scrollDuration));
     await tester.pumpAndSettle();
     unawaited(itemScrollController.scrollTo(
-        index: defaultItemCount, duration: scrollDuration));
+        index: defaultItemCount - 1, duration: scrollDuration));
     await tester.pumpAndSettle();
 
-    expect(tester.getBottomLeft(find.text('Item $defaultItemCount')).dy,
+    expect(tester.getBottomLeft(find.text('Item ${defaultItemCount - 1}')).dy,
         screenHeight);
   });
 
@@ -1390,7 +1394,7 @@ void main() {
     final itemScrollController = ItemScrollController();
     await setUpWidgetTest(tester, itemScrollController: itemScrollController);
 
-    itemScrollController.jumpTo(index: defaultItemCount);
+    itemScrollController.jumpTo(index: defaultItemCount - 1);
     await tester.pumpAndSettle();
 
     itemScrollController.jumpTo(index: 0, alignment: 0.3);

--- a/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
@@ -26,7 +26,7 @@ void main() {
     ItemPositionsListener itemPositionsListener,
     int initialIndex = 0,
     double initialAlignment = 0.0,
-    int itemCount,
+    int itemCount = defaultItemCount,
     ScrollPhysics physics,
     bool addSemanticIndexes = true,
     int semanticChildCount,
@@ -37,7 +37,6 @@ void main() {
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     tester.binding.window.physicalSizeTestValue =
         const Size(screenWidth, screenHeight);
-    itemCount = itemCount ?? defaultItemCount;
 
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

this PR ensures that itemBuilders not be called with indices > itemCount - 1.

## Related Issues

fixes #42 
fixes #77

The issues above involve updating `itemCount` after a page state restore (thus `itemCount` is less than the previously stored position), and the `itemBuilder` will throw due to index out of bounds when getting an item from a backing list.

## Checklist

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
