### PR TITLE
Expose cacheExtent property

### DIFF
--- a/packages/scrollable_positioned_list/CHANGELOG.md
+++ b/packages/scrollable_positioned_list/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.4
+
+  * Expose `cacheExtent` property. Fixes
+    [issue #90](https://github.com/google/flutter.widgets/issues/90).
+
 # 0.1.3
 
   * Don't build items when `itemCount` is 0. Fixes

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -262,7 +262,8 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
                     itemPositionNotifier: backItemPositionNotifier,
                     scrollDirection: widget.scrollDirection,
                     reverse: widget.reverse,
-                    cacheExtent: constraints.maxHeight * _screenScrollCount,
+                    cacheExtent: widget.cacheExtent ??
+                        constraints.maxHeight * _screenScrollCount,
                     alignment: backAlignment,
                     physics: widget.physics,
                     addSemanticIndexes: widget.addSemanticIndexes,
@@ -293,7 +294,8 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
                         controller: frontScrollController,
                         scrollDirection: widget.scrollDirection,
                         reverse: widget.reverse,
-                        cacheExtent: constraints.maxHeight * _screenScrollCount,
+                        cacheExtent: widget.cacheExtent ??
+                            constraints.maxHeight * _screenScrollCount,
                         alignment: frontAlignment,
                         physics: widget.physics,
                         addSemanticIndexes: widget.addSemanticIndexes,

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -50,6 +50,7 @@ class ScrollablePositionedList extends StatefulWidget {
     this.addSemanticIndexes = true,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
+    this.cacheExtent,
   })  : assert(itemCount != null),
         assert(itemBuilder != null),
         itemPositionNotifier = itemPositionsListener,
@@ -75,6 +76,7 @@ class ScrollablePositionedList extends StatefulWidget {
     this.addSemanticIndexes = true,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
+    this.cacheExtent,
   })  : assert(itemCount != null),
         assert(itemBuilder != null),
         assert(separatorBuilder != null),
@@ -147,6 +149,9 @@ class ScrollablePositionedList extends StatefulWidget {
   ///
   /// See [SliverChildBuilderDelegate.addRepaintBoundaries].
   final bool addRepaintBoundaries;
+
+  /// {@macro flutter.widgets.scrollable.cacheExtent}
+  final double cacheExtent;
 
   @override
   State<StatefulWidget> createState() => _ScrollablePositionedListState();

--- a/packages/scrollable_positioned_list/pubspec.yaml
+++ b/packages/scrollable_positioned_list/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scrollable_positioned_list
-version: 0.1.3
+version: 0.1.4
 description: >
   A list with helper methods to programmatically scroll to an item.
 homepage: https://github.com/google/flutter.widgets
@@ -11,9 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.1
+  meta: ^1.1.8
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.9.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Description

This PR exposes `cacheExtent` property to constructors, so the user can set a custom one. If not provided, previous behavior stays (defaults to `constraints.maxHeight * _screenScrollCount`).

## Related Issues

Fixes #90 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I signed the [CLA].
- [X] All tests from running `flutter test` pass.
- [X] `flutter analyze` does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
