### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-issue.md
@@ -1,0 +1,28 @@
+---
+name: New issue
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem description
+<!-- Please describe the bug or feature request.  This repository includes multiple packages, so please specify which package you are reporting the issue against. -->
+
+## Steps to reproduce
+<!-- If you are reporting a bug, a minimal, complete, verifiable example (ideally a test case) would help a lot.  How reproducible is the problem? -->
+
+1.
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Actual behavior
+<!-- What actually happened? -->
+
+## Environment
+<!-- List relevant details about the environment where you encountered the problem (e.g. OS version). -->
+
+## Additional details
+<!-- Include any other relevant details, such as stacktraces. -->


### PR DESCRIPTION
Add an issue template, primarily to remind people people to specify what package their issue is about.