### PR TITLE
[ScrollablePositionedList] Ensure that itemBuilders not be called with indices > itemCount - 1.

### DIFF
--- a/packages/scrollable_positioned_list/CHANGELOG.md
+++ b/packages/scrollable_positioned_list/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.4
+
+  *  itemBuilders should not be called with indices > itemCount - 1.  Fixes
+     [issue #42](https://github.com/google/flutter.widgets/issues/42) and
+     [issue #77](https://github.com/google/flutter.widgets/issues/77).
+
 # 0.1.3
 
   * Don't build items when `itemCount` is 0. Fixes

--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -44,7 +44,8 @@ class PositionedList extends StatefulWidget {
     this.addRepaintBoundaries = true,
     this.addAutomaticKeepAlives = true,
   })  : assert(itemCount != null),
-        assert(itemBuilder != null);
+        assert(itemBuilder != null),
+        assert((positionedIndex == 0) || (positionedIndex < itemCount));
 
   /// Number of items the [itemBuilder] can produce.
   final int itemCount;
@@ -207,7 +208,8 @@ class _PositionedListState extends State<PositionedList> {
                 ),
               ),
             ),
-            if (widget.positionedIndex < widget.itemCount - 1)
+            if (widget.positionedIndex >= 0 &&
+                widget.positionedIndex < widget.itemCount - 1)
               SliverPadding(
                 padding: _trailingSliverPadding,
                 sliver: SliverList(

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -222,6 +222,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontTarget = initialPosition?.index ?? widget.initialScrollIndex;
     frontAlignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
+    if (widget.itemCount != null && frontTarget > widget.itemCount - 1) {
+      frontTarget = widget.itemCount - 1;
+    }
     widget.itemScrollController?._attach(this);
     frontItemPositionNotifier.itemPositions.addListener(_updatePositions);
     backItemPositionNotifier.itemPositions.addListener(_updatePositions);
@@ -233,6 +236,23 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontItemPositionNotifier.itemPositions.removeListener(_updatePositions);
     backItemPositionNotifier.itemPositions.removeListener(_updatePositions);
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(ScrollablePositionedList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.itemCount != null) {
+      if (frontTarget > widget.itemCount - 1) {
+        setState(() {
+          frontTarget = widget.itemCount - 1;
+        });
+      }
+      if (backTarget > widget.itemCount - 1) {
+        setState(() {
+          backTarget = widget.itemCount - 1;
+        });
+      }
+    }
   }
 
   @override
@@ -307,6 +327,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
 
   void _jumpTo({@required int index, double alignment}) {
     cancelScrollCallback?.call();
+    if (index > widget.itemCount - 1) {
+      index = widget.itemCount - 1;
+    }
     if (_showFrontList) {
       frontScrollController.jumpTo(0);
       setState(() {
@@ -327,6 +350,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
       double alignment,
       @required Duration duration,
       Curve curve = Curves.linear}) async {
+    if (index > widget.itemCount - 1) {
+      index = widget.itemCount - 1;
+    }
     if (cancelScrollCallback != null) {
       cancelScrollCallback();
       SchedulerBinding.instance.addPostFrameCallback((_) {

--- a/packages/scrollable_positioned_list/pubspec.yaml
+++ b/packages/scrollable_positioned_list/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scrollable_positioned_list
-version: 0.1.3
+version: 0.1.4
 description: >
   A list with helper methods to programmatically scroll to an item.
 homepage: https://github.com/google/flutter.widgets


### PR DESCRIPTION
Ensure that itemBuilders not be called with indices > itemCount - 1.

fixes #42
fixes #77

Closes https://github.com/google/flutter.widgets/pull/89
Original author, and much thanks to, lkho <llhmtc@gmail.com>

PiperOrigin-RevId: 307163952