### PR TITLE
ScrollablePositionedList.builder.itemBuilder index == -1

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -222,7 +222,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontTarget = initialPosition?.index ?? widget.initialScrollIndex;
     frontAlignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
-    if (widget.itemCount != null && frontTarget > widget.itemCount - 1) {
+    if (widget.itemCount != null &&
+        widget.itemCount > 0 &&
+        frontTarget > widget.itemCount - 1) {
       frontTarget = widget.itemCount - 1;
     }
     widget.itemScrollController?._attach(this);
@@ -242,15 +244,22 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
   void didUpdateWidget(ScrollablePositionedList oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.itemCount != null) {
-      if (frontTarget > widget.itemCount - 1) {
+      if (widget.itemCount == 0) {
         setState(() {
-          frontTarget = widget.itemCount - 1;
+          frontTarget = 0;
+          backTarget = 0;
         });
-      }
-      if (backTarget > widget.itemCount - 1) {
-        setState(() {
-          backTarget = widget.itemCount - 1;
-        });
+      } else {
+        if (frontTarget > widget.itemCount - 1) {
+          setState(() {
+            frontTarget = widget.itemCount - 1;
+          });
+        }
+        if (backTarget > widget.itemCount - 1) {
+          setState(() {
+            backTarget = widget.itemCount - 1;
+          });
+        }
       }
     }
   }

--- a/packages/scrollable_positioned_list/test/separated_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/separated_positioned_list_test.dart
@@ -57,6 +57,50 @@ void main() {
     expect(find.text('Separator 0'), findsNothing);
   });
 
+  testWidgets('Empty list then update to single item list',
+      (WidgetTester tester) async {
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    tester.binding.window.physicalSizeTestValue =
+        const Size(screenWidth, screenHeight);
+
+    final itemScrollController = ItemScrollController();
+    final itemPositionsListener = ItemPositionsListener.create();
+    final itemCount = ValueNotifier<int>(0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder(
+          valueListenable: itemCount,
+          builder: (context, itemCount, child) {
+            return ScrollablePositionedList.separated(
+              initialScrollIndex: 0,
+              initialAlignment: 0,
+              itemCount: itemCount,
+              itemScrollController: itemScrollController,
+              itemPositionsListener: itemPositionsListener,
+              itemBuilder: (context, index) => SizedBox(
+                height: itemHeight,
+                child: Text('Item $index'),
+              ),
+              separatorBuilder: (context, index) => SizedBox(
+                height: separatorHeight,
+                child: Text('Separator $index'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    itemCount.value = 1;
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Separator 0'), findsNothing);
+  });
+
   testWidgets('Short list', (WidgetTester tester) async {
     await setUpWidgetTest(tester, itemCount: 3);
 


### PR DESCRIPTION
## Description
Fixes the issue when item count updated from zero to one and `index` in `itemBuilder` becomes `-1`

## Related Issues
#104 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
