### PR TITLE
Copybara sync

### DIFF
--- a/packages/scrollable_positioned_list/CHANGELOG.md
+++ b/packages/scrollable_positioned_list/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.1.5
 
   * Added minCacheExtent to ScrollablePositionedList
+  * Fixes the issue when item count updated from zero to one and `index` in 
+    `itemBuilder` becomes `-1`.  Fixes
+    [issue #104](https://github.com/google/flutter.widgets/issues/104).
 
 # 0.1.4
 

--- a/packages/scrollable_positioned_list/CHANGELOG.md
+++ b/packages/scrollable_positioned_list/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.5
+
+  * Added minCacheExtent to ScrollablePositionedList
+
 # 0.1.4
 
   *  itemBuilders should not be called with indices > itemCount - 1.  Fixes

--- a/packages/scrollable_positioned_list/example/lib/scrollable_positioned_list_example.dart
+++ b/packages/scrollable_positioned_list/example/lib/scrollable_positioned_list_example.dart
@@ -93,7 +93,6 @@ class _ScrollablePositionedListPageState
           SizedBox(
             width: 200,
             child: Slider(
-              useV2Slider: true,
               value: alignment,
               onChanged: (double value) => setState(() => alignment = value),
             ),

--- a/packages/scrollable_positioned_list/example/lib/scrollable_positioned_list_example.dart
+++ b/packages/scrollable_positioned_list/example/lib/scrollable_positioned_list_example.dart
@@ -93,6 +93,7 @@ class _ScrollablePositionedListPageState
           SizedBox(
             width: 200,
             child: Slider(
+              useV2Slider: true,
               value: alignment,
               onChanged: (double value) => setState(() => alignment = value),
             ),

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -235,7 +235,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     frontTarget = initialPosition?.index ?? widget.initialScrollIndex;
     frontAlignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
-    if (widget.itemCount != null && frontTarget > widget.itemCount - 1) {
+    if (widget.itemCount != null &&
+        widget.itemCount > 0 &&
+        frontTarget > widget.itemCount - 1) {
       frontTarget = widget.itemCount - 1;
     }
     widget.itemScrollController?._attach(this);
@@ -255,15 +257,22 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
   void didUpdateWidget(ScrollablePositionedList oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.itemCount != null) {
-      if (frontTarget > widget.itemCount - 1) {
+      if (widget.itemCount == 0) {
         setState(() {
-          frontTarget = widget.itemCount - 1;
+          frontTarget = 0;
+          backTarget = 0;
         });
-      }
-      if (backTarget > widget.itemCount - 1) {
-        setState(() {
-          backTarget = widget.itemCount - 1;
-        });
+      } else {
+        if (frontTarget > widget.itemCount - 1) {
+          setState(() {
+            frontTarget = widget.itemCount - 1;
+          });
+        }
+        if (backTarget > widget.itemCount - 1) {
+          setState(() {
+            backTarget = widget.itemCount - 1;
+          });
+        }
       }
     }
   }

--- a/packages/scrollable_positioned_list/pubspec.yaml
+++ b/packages/scrollable_positioned_list/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scrollable_positioned_list
-version: 0.1.4
+version: 0.1.5
 description: >
   A list with helper methods to programmatically scroll to an item.
 homepage: https://github.com/google/flutter.widgets

--- a/packages/scrollable_positioned_list/test/separated_scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/separated_scrollable_positioned_list_test.dart
@@ -483,6 +483,50 @@ void main() {
 
     expect(find.byKey(key), findsOneWidget);
   });
+
+  testWidgets('Empty list then update to single item list',
+      (WidgetTester tester) async {
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    tester.binding.window.physicalSizeTestValue =
+        const Size(screenWidth, screenHeight);
+
+    final itemScrollController = ItemScrollController();
+    final itemPositionsListener = ItemPositionsListener.create();
+    final itemCount = ValueNotifier<int>(0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder(
+          valueListenable: itemCount,
+          builder: (context, itemCount, child) {
+            return ScrollablePositionedList.separated(
+              initialScrollIndex: 0,
+              initialAlignment: 0,
+              itemCount: itemCount,
+              itemScrollController: itemScrollController,
+              itemPositionsListener: itemPositionsListener,
+              itemBuilder: (context, index) => SizedBox(
+                height: itemHeight,
+                child: Text('Item $index'),
+              ),
+              separatorBuilder: (context, index) => SizedBox(
+                height: separatorHeight,
+                child: Text('Separator $index'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    itemCount.value = 1;
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Separator 0'), findsNothing);
+  });
 }
 
 double _screenProportion({double numberOfItems, double numberOfSeparators}) =>


### PR DESCRIPTION
## Description
ScrollablePositionedList: Fixes the issue when item count updated from zero to one and `index` in `itemBuilder` becomes `-1`

Add minCacheExtent to ScrollablePositionedList.

## Related Issues
#104
#90

Closes https://github.com/google/flutter.widgets/pull/106
Closes https://github.com/google/flutter.widgets/pull/109
Closes https://github.com/google/flutter.widgets/pull/91

Thanks to Zazo032, vasilich6107, and keep2iron for original PRs.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X ] I signed the [CLA].
- [X ] All tests from running `flutter test` pass.
- [X ] `flutter analyze` does not report any problems on my PR.
- [X ] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
