### PR TITLE
Fix exception with minScrollExtent > maxScrollExtent.

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/viewport.dart
+++ b/packages/scrollable_positioned_list/lib/src/viewport.dart
@@ -139,9 +139,9 @@ class UnboundedRenderViewport extends RenderViewport {
         // *** Difference from [RenderViewport].
         final top = _minScrollExtent + mainAxisExtent * anchor;
         final bottom = _maxScrollExtent - mainAxisExtent * (1.0 - anchor);
-        final max = math.max(math.min(0.0, top), bottom);
-        final min = math.min(top, max);
-        if (offset.applyContentDimensions(min, max)) break;
+        final maxScrollOffset = math.max(math.min(0.0, top), bottom);
+        final minScrollOffset = math.min(top, maxScrollOffset);
+        if (offset.applyContentDimensions(minScrollOffset, maxScrollOffset)) break;
         // *** End of difference from [RenderViewport].
       }
       count += 1;

--- a/packages/scrollable_positioned_list/lib/src/viewport.dart
+++ b/packages/scrollable_positioned_list/lib/src/viewport.dart
@@ -4,9 +4,9 @@
 
 import 'dart:math' as math;
 
-import 'package:meta/meta.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 
 /// A render object that is bigger on the inside.
 ///
@@ -137,11 +137,11 @@ class UnboundedRenderViewport extends RenderViewport {
         offset.correctBy(correction);
       } else {
         // *** Difference from [RenderViewport].
-        if (offset.applyContentDimensions(
-          _minScrollExtent + mainAxisExtent * anchor,
-          math.max(math.min(0.0, _minScrollExtent + mainAxisExtent * anchor),
-              _maxScrollExtent - mainAxisExtent * (1.0 - anchor)),
-        )) break;
+        final top = _minScrollExtent + mainAxisExtent * anchor;
+        final bottom = _maxScrollExtent - mainAxisExtent * (1.0 - anchor);
+        final max = math.max(math.min(0.0, top), bottom);
+        final min = math.min(top, max);
+        if (offset.applyContentDimensions(min, max)) break;
         // *** End of difference from [RenderViewport].
       }
       count += 1;

--- a/packages/scrollable_positioned_list/lib/src/viewport.dart
+++ b/packages/scrollable_positioned_list/lib/src/viewport.dart
@@ -141,7 +141,8 @@ class UnboundedRenderViewport extends RenderViewport {
         final bottom = _maxScrollExtent - mainAxisExtent * (1.0 - anchor);
         final maxScrollOffset = math.max(math.min(0.0, top), bottom);
         final minScrollOffset = math.min(top, maxScrollOffset);
-        if (offset.applyContentDimensions(minScrollOffset, maxScrollOffset)) break;
+        if (offset.applyContentDimensions(minScrollOffset, maxScrollOffset))
+          break;
         // *** End of difference from [RenderViewport].
       }
       count += 1;

--- a/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
@@ -1848,4 +1848,14 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('Position list when not enough above top item to fill viewport',
+      (WidgetTester tester) async {
+    await setUpWidgetTest(tester,
+        itemCount: 2, initialAlignment: 0.8, initialIndex: 1);
+
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(find.text('Item 0')).dy, 0);
+  });
 }

--- a/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
@@ -1855,11 +1855,11 @@ void main() {
       tester,
       itemCount: 2,
       initialAlignment: 0.8,
-      initialIndex: 1,
+      initialIndex: 0,
     );
 
     await tester.pumpAndSettle();
 
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 0);
+    expect(tester.getTopLeft(find.text('Item 0')).dy, screenHeight * 0.8);
   });
 }

--- a/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/scrollable_positioned_list_test.dart
@@ -1851,8 +1851,12 @@ void main() {
 
   testWidgets('Position list when not enough above top item to fill viewport',
       (WidgetTester tester) async {
-    await setUpWidgetTest(tester,
-        itemCount: 2, initialAlignment: 0.8, initialIndex: 1);
+    await setUpWidgetTest(
+      tester,
+      itemCount: 2,
+      initialAlignment: 0.8,
+      initialIndex: 1,
+    );
 
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Description
Fix exception with minScrollExtent > maxScrollExtent.

Fixes exception for #38.
Still more work needed to improve behaviour.

## Related Issues

https://github.com/google/flutter.widgets/issues/38

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I signed the [CLA].
- [ x] All tests from running `flutter test` pass.
- [x ] `flutter analyze` does not report any problems on my PR.
- [ x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
