### PR TITLE
Rename flutter_tree to flutter_simple_treeview - PR1

### DIFF
--- a/packages/flutter_simple_treeview/CHANGELOG.md
+++ b/packages/flutter_simple_treeview/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0
+
+  * Publish unitial version.

--- a/packages/flutter_simple_treeview/LICENSE
+++ b/packages/flutter_simple_treeview/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2018 the Dart project authors, Inc. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/flutter_simple_treeview/README.md
+++ b/packages/flutter_simple_treeview/README.md
@@ -1,0 +1,27 @@
+# flutter_simple_treeview
+This widget visualises a tree structure, where a node can be any widget.
+
+## Demo
+
+[https://f-tree.codemagic.app](https://f-tree.codemagic.app)
+
+## Usage
+
+```
+                  TreeView(nodes: [
+                    TreeNode(content: Text("root1")),
+                    TreeNode(
+                      content: Text("root2"),
+                      children: [
+                        TreeNode(content: Text("child21")),
+                        TreeNode(content: Text("child22")),
+                        TreeNode(
+                          content: Text("root23"),
+                          children: [
+                            TreeNode(content: Text("child231")),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ]),
+```

--- a/packages/flutter_simple_treeview/lib/flutter_simple_treeview.dart
+++ b/packages/flutter_simple_treeview/lib/flutter_simple_treeview.dart
@@ -1,0 +1,8 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+export 'src/tree_node.dart';
+export 'src/tree_view.dart';

--- a/packages/flutter_simple_treeview/lib/src/builder.dart
+++ b/packages/flutter_simple_treeview/lib/src/builder.dart
@@ -1,0 +1,28 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+
+import 'node_widget.dart';
+import 'tree_node.dart';
+import 'tree_state.dart';
+
+/// Builds set of [nodes] respecting [state], [indent] and [iconSize].
+Widget buildNodes(
+    List<TreeNode> nodes, double indent, TreeState state, double iconSize) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      for (var node in nodes)
+        NodeWidget(
+          treeNode: node,
+          indent: indent,
+          state: state,
+          iconSize: iconSize,
+        )
+    ],
+  );
+}

--- a/packages/flutter_simple_treeview/lib/src/node_widget.dart
+++ b/packages/flutter_simple_treeview/lib/src/node_widget.dart
@@ -1,0 +1,69 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+
+import 'builder.dart';
+import 'tree_node.dart';
+import 'tree_state.dart';
+
+/// Widget, that display one [TreeNode] with its children.
+class NodeWidget extends StatefulWidget {
+  final TreeNode treeNode;
+  final double indent;
+  final double iconSize;
+  final TreeState state;
+
+  const NodeWidget(
+      {Key key, this.treeNode, this.indent, this.state, this.iconSize})
+      : super(key: key);
+
+  @override
+  _NodeWidgetState createState() => _NodeWidgetState();
+}
+
+class _NodeWidgetState extends State<NodeWidget> {
+  bool get _isLeaf {
+    return widget.treeNode.children == null || widget.treeNode.children.isEmpty;
+  }
+
+  bool get _isExpanded {
+    return widget.state.isNodeExpanded(widget.treeNode.key);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var icon =
+        _isLeaf ? null : _isExpanded ? Icons.expand_more : Icons.chevron_right;
+
+    void onIconPressed() => _isLeaf
+        ? null
+        : () => setState(() {
+              widget.state.toggleNodeExpanded(widget.treeNode.key);
+            });
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            IconButton(
+              iconSize: widget.iconSize ?? 24.0,
+              icon: Icon(icon),
+              onPressed: onIconPressed,
+            ),
+            widget.treeNode.content,
+          ],
+        ),
+        if (_isExpanded && !_isLeaf)
+          Padding(
+            padding: EdgeInsets.only(left: widget.indent),
+            child: buildNodes(widget.treeNode.children, widget.indent,
+                widget.state, widget.iconSize),
+          )
+      ],
+    );
+  }
+}

--- a/packages/flutter_simple_treeview/lib/src/tree_node.dart
+++ b/packages/flutter_simple_treeview/lib/src/tree_node.dart
@@ -1,0 +1,18 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+
+/// One node of a tree.
+class TreeNode {
+  final List<TreeNode> children;
+  final Widget content;
+
+  /// The key is used to persist expanded state
+  final Key key;
+
+  TreeNode({Key key, this.children, this.content}) : key = key ?? UniqueKey();
+}

--- a/packages/flutter_simple_treeview/lib/src/tree_state.dart
+++ b/packages/flutter_simple_treeview/lib/src/tree_state.dart
@@ -1,0 +1,25 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/foundation.dart';
+
+/// The state of a tree.
+///
+/// This state is passed to all tree nodes.
+class TreeState {
+  final bool allNodesExpanded;
+  final Map<Key, bool> state = <Key, bool>{};
+
+  TreeState(this.allNodesExpanded);
+
+  bool isNodeExpanded(Key key) {
+    return state[key] ?? allNodesExpanded;
+  }
+
+  void toggleNodeExpanded(Key key) {
+    state[key] = !isNodeExpanded(key);
+  }
+}

--- a/packages/flutter_simple_treeview/lib/src/tree_view.dart
+++ b/packages/flutter_simple_treeview/lib/src/tree_view.dart
@@ -1,0 +1,45 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+
+import 'builder.dart';
+import 'tree_node.dart';
+import 'tree_state.dart';
+
+/// Tree view with collapsable and expandable nodes.
+class TreeView extends StatefulWidget {
+  final List<TreeNode> nodes;
+  final double indent;
+  final double iconSize;
+  final bool allNodesExpanded;
+
+  const TreeView(
+      {Key key,
+      this.nodes,
+      this.indent = 40,
+      this.allNodesExpanded = false,
+      this.iconSize})
+      : super(key: key);
+
+  @override
+  _TreeViewState createState() => _TreeViewState();
+}
+
+class _TreeViewState extends State<TreeView> {
+  TreeState _state;
+
+  @override
+  void initState() {
+    _state = TreeState(widget.allNodesExpanded);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return buildNodes(widget.nodes, widget.indent, _state, widget.iconSize);
+  }
+}

--- a/packages/flutter_simple_treeview/pubspec.yaml
+++ b/packages/flutter_simple_treeview/pubspec.yaml
@@ -1,0 +1,18 @@
+name: flutter_simple_treeview
+version: 1.0.0
+description: >
+  A widget, that visualises a tree structure, where a node can be any widget.
+homepage: https://github.com/google/flutter.widgets
+
+environment:
+  sdk: ">=2.3.0 <3.0.0"
+  flutter: ^1.12.13+hotfix.5
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  test:
+  flutter_test:
+    sdk: flutter

--- a/packages/flutter_simple_treeview/test/tree_state_test.dart
+++ b/packages/flutter_simple_treeview/test/tree_state_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+import 'package:flutter_simple_treeview/src/tree_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Key k1 = UniqueKey();
+  Key k2 = UniqueKey();
+
+  test('Initial state is equal to default state.', () {
+    for (var allExpanded in [true, false]) {
+      var state = TreeState(allExpanded);
+      expect(state.isNodeExpanded(k1), allExpanded);
+    }
+  });
+
+  test('Toggle works.', () {
+    for (var allExpanded in [true, false]) {
+      var state = TreeState(allExpanded);
+      state.toggleNodeExpanded(k1);
+      expect(state.isNodeExpanded(k1), !allExpanded);
+      state.toggleNodeExpanded(k1);
+      expect(state.isNodeExpanded(k1), allExpanded);
+    }
+  });
+
+  test('States are independant.', () {
+    for (var allExpanded in [true, false]) {
+      var state = TreeState(allExpanded);
+      state.toggleNodeExpanded(k1);
+      expect(state.isNodeExpanded(k2), allExpanded);
+      state.toggleNodeExpanded(k1);
+      expect(state.isNodeExpanded(k2), allExpanded);
+      state.toggleNodeExpanded(k2);
+      expect(state.isNodeExpanded(k1), allExpanded);
+    }
+  });
+}

--- a/packages/flutter_simple_treeview/test/tree_view_test.dart
+++ b/packages/flutter_simple_treeview/test/tree_view_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_simple_treeview/flutter_simple_treeview.dart';
+
+/// Wraps widget to MaterialApp and pumps.
+Future<void> wrapAndPump(WidgetTester tester, Widget widget) async {
+  var wrapped = MaterialApp(
+    home: SingleChildScrollView(
+        child: SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Card(child: widget),
+    )),
+  );
+  await tester.pumpWidget(wrapped);
+}
+
+void main() {
+  testWidgets('Tree renders all nodes when expanded.',
+      (WidgetTester tester) async {
+    var widget = TreeView(
+      allNodesExpanded: true,
+      nodes: [
+        TreeNode(content: Text('n0')),
+        TreeNode(content: Text('n1')),
+        TreeNode(
+          content: Text('n2'),
+          children: [
+            TreeNode(content: Text('n3')),
+            TreeNode(content: Text('n4')),
+            TreeNode(
+              content: Text('n5'),
+              children: [
+                TreeNode(content: Text('n6')),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    await wrapAndPump(tester, widget);
+
+    for (var i = 0; i < 7; i++) {
+      expect(
+        find.byWidgetPredicate(
+            (widget) => widget is Text && widget.data == 'n$i'),
+        findsOneWidget,
+      );
+    }
+  });
+}


### PR DESCRIPTION
PiperOrigin-RevId: 312307568

## Description

This is first part of renaming. I will delete flutter_tree with a separate PR, externally, without copybara.

## Related Issues

NA

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
