### PR TITLE
Fixed error: "type 'double' is not a subtype of type 'ItemPosition'"

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -229,7 +229,14 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
   @override
   void initState() {
     super.initState();
-    ItemPosition initialPosition = PageStorage.of(context).readState(context);
+    var page = PageStorage.of(context).readState(context);
+    
+    ItemPosition initialPosition;
+    if (page is ItemPosition)
+      initialPosition = page;
+    else if (page is int) 
+      initialPosition = ItemPosition(index: page);
+    
     frontTarget = initialPosition?.index ?? widget.initialScrollIndex;
     frontAlignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;


### PR DESCRIPTION
After displaying\hiding\displaying the widget, I received the error: "type 'double' is not. a subtype of type 'ItemPosition'"

It is dirty code but solves the bug.
