### PR TITLE
fixes: https://github.com/google/flutter.widgets/issues/173

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -316,12 +316,14 @@ class _PositionedListState extends State<PositionedList> {
             final itemOffset = reveal -
                 viewport.offset.pixels +
                 viewport.anchor * viewport.size.height;
-            positions.add(ItemPosition(
-                index: key.value,
-                itemLeadingEdge: itemOffset.round() /
-                    scrollController.position.viewportDimension,
-                itemTrailingEdge: (itemOffset + box.size.height).round() /
-                    scrollController.position.viewportDimension));
+            if (itemOffset.isFinite) {
+              positions.add(ItemPosition(
+                  index: key.value,
+                  itemLeadingEdge: itemOffset.round() /
+                      scrollController.position.viewportDimension,
+                  itemTrailingEdge: (itemOffset + box.size.height).round() /
+                      scrollController.position.viewportDimension));
+            }
           } else {
             final itemOffset =
                 box.localToGlobal(Offset.zero, ancestor: viewport).dx;


### PR DESCRIPTION
## Description

This is a simple bug fix that prevent scrolling crash because of `Infinity or NaN toInt` converting.

## Related Issues

https://github.com/google/flutter.widgets/issues/173

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
