### PR TITLE
Remove unused dart: import

### DIFF
--- a/packages/flutter_simple_treeview/example/lib/trees/tree_from_json.dart
+++ b/packages/flutter_simple_treeview/example/lib/trees/tree_from_json.dart
@@ -5,7 +5,6 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_simple_treeview/flutter_simple_treeview.dart';


### PR DESCRIPTION
## Description

Remove unused `dart:` import. A bug in the analyzer is causing it to not report this unused import currently. This PR is part of a cleanup to allow fixing the bug.

## Related Issues

See https://github.com/dart-lang/sdk/issues/45028

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [ ] All tests from running `flutter test` pass.
- [ ] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
