### PR TITLE
Sliver visibility detector

### DIFF
--- a/packages/visibility_detector/example/lib/main.dart
+++ b/packages/visibility_detector/example/lib/main.dart
@@ -256,10 +256,7 @@ class SliverDemoPageSecondaryAxis extends StatelessWidget {
         scrollDirection: secondaryAxis,
         reverse: reverse,
         slivers: [
-          // NEW no padding left and right
-          //SliverPadding(padding: EdgeInsets.only(left: externalCellPadding)),
           SliverToBoxAdapter(child: SizedBox(width: 5)),
-
           // Sliver version renders up to 20 columns.
           for (var secondaryIndex = 0; secondaryIndex < 20; secondaryIndex++)
             DemoPageCell(
@@ -267,9 +264,7 @@ class SliverDemoPageSecondaryAxis extends StatelessWidget {
               secondaryIndex: secondaryIndex,
               useSlivers: true,
             ),
-                    SliverToBoxAdapter(child: SizedBox(width: 5)),
-
-     //     SliverPadding(padding: EdgeInsets.only(right: externalCellPadding)),
+          SliverToBoxAdapter(child: SizedBox(width: 5)),
         ],
       ),
     );

--- a/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
@@ -12,16 +14,15 @@ import 'visibility_detector_layer.dart';
 
 /// The [RenderObject] corresponding to the [SliverVisibilityDetector] widget.
 ///
-/// [RenderSliverVisibilityDetector] is a bridge between [VisibilityDetector]
-/// and [VisibilityDetectorLayer] for sliver widgets.
+/// [RenderSliverVisibilityDetector] is a bridge between
+/// [SliverVisibilityDetector] and [VisibilityDetectorLayer].
 class RenderSliverVisibilityDetector extends RenderProxySliver {
   /// Constructor.  See the corresponding properties for parameter details.
   RenderSliverVisibilityDetector({
     RenderSliver? sliver,
     required this.key,
     required VisibilityChangedCallback? onVisibilityChanged,
-  })   : assert(key != null),
-        _onVisibilityChanged = onVisibilityChanged,
+  })   : _onVisibilityChanged = onVisibilityChanged,
         super(sliver);
 
   /// The key for the corresponding [VisibilityDetector] widget.
@@ -55,9 +56,38 @@ class RenderSliverVisibilityDetector extends RenderProxySliver {
       return;
     }
 
+    Rect widgetRect;
+    switch (applyGrowthDirectionToAxisDirection(
+      constraints.axisDirection,
+      constraints.growthDirection,
+    )) {
+      case AxisDirection.down:
+        widgetRect = Offset(0, -constraints.scrollOffset) &
+            Size(constraints.crossAxisExtent, geometry!.scrollExtent);
+        break;
+      case AxisDirection.up:
+        final startOffset = geometry!.paintExtent +
+            constraints.scrollOffset -
+            geometry!.scrollExtent;
+        widgetRect = Offset(0, min(startOffset, 0)) &
+            Size(constraints.crossAxisExtent, geometry!.scrollExtent);
+        break;
+      case AxisDirection.right:
+        widgetRect = Offset(-constraints.scrollOffset, 0) &
+            Size(geometry!.scrollExtent, constraints.crossAxisExtent);
+        break;
+      case AxisDirection.left:
+        final startOffset = geometry!.paintExtent +
+            constraints.scrollOffset -
+            geometry!.scrollExtent;
+        widgetRect = Offset(min(startOffset, 0), 0) &
+            Size(geometry!.scrollExtent, constraints.crossAxisExtent);
+        break;
+    }
+
     final layer = VisibilityDetectorLayer(
         key: key,
-        widgetSize: semanticBounds.size,
+        widgetRect: widgetRect,
         paintOffset: offset,
         onVisibilityChanged: onVisibilityChanged!);
     context.pushLayer(layer, super.paint, offset);

--- a/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
@@ -10,19 +10,19 @@ import 'package:flutter/rendering.dart';
 import 'visibility_detector.dart';
 import 'visibility_detector_layer.dart';
 
-/// The [RenderObject] corresponding to the [VisibilityDetector] widget.
+/// The [RenderObject] corresponding to the [SliverVisibilityDetector] widget.
 ///
-/// [RenderVisibilityDetector] is a bridge between [VisibilityDetector] and
-/// [VisibilityDetectorLayer].
-class RenderVisibilityDetector extends RenderProxyBox {
+/// [RenderSliverVisibilityDetector] is a bridge between [VisibilityDetector]
+/// and [VisibilityDetectorLayer] for sliver widgets.
+class RenderSliverVisibilityDetector extends RenderProxySliver {
   /// Constructor.  See the corresponding properties for parameter details.
-  RenderVisibilityDetector({
-    RenderBox? child,
+  RenderSliverVisibilityDetector({
+    RenderSliver? sliver,
     required this.key,
     required VisibilityChangedCallback? onVisibilityChanged,
   })   : assert(key != null),
         _onVisibilityChanged = onVisibilityChanged,
-        super(child);
+        super(sliver);
 
   /// The key for the corresponding [VisibilityDetector] widget.
   final Key key;

--- a/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_sliver_visibility_detector.dart
@@ -1,0 +1,65 @@
+// Copyright 2018 the Dart project authors.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+
+import 'visibility_detector.dart';
+import 'visibility_detector_layer.dart';
+
+/// The [RenderObject] corresponding to the [VisibilityDetector] widget.
+///
+/// [RenderVisibilityDetector] is a bridge between [VisibilityDetector] and
+/// [VisibilityDetectorLayer].
+class RenderVisibilityDetector extends RenderProxyBox {
+  /// Constructor.  See the corresponding properties for parameter details.
+  RenderVisibilityDetector({
+    RenderBox? child,
+    required this.key,
+    required VisibilityChangedCallback? onVisibilityChanged,
+  })   : assert(key != null),
+        _onVisibilityChanged = onVisibilityChanged,
+        super(child);
+
+  /// The key for the corresponding [VisibilityDetector] widget.
+  final Key key;
+
+  VisibilityChangedCallback? _onVisibilityChanged;
+
+  /// See [VisibilityDetector.onVisibilityChanged].
+  VisibilityChangedCallback? get onVisibilityChanged => _onVisibilityChanged;
+
+  /// Used by [VisibilityDetector.updateRenderObject].
+  set onVisibilityChanged(VisibilityChangedCallback? value) {
+    _onVisibilityChanged = value;
+    markNeedsCompositingBitsUpdate();
+    markNeedsPaint();
+  }
+
+  // See [RenderObject.alwaysNeedsCompositing].
+  @override
+  bool get alwaysNeedsCompositing => onVisibilityChanged != null;
+
+  /// See [RenderObject.paint].
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (onVisibilityChanged == null) {
+      // No need to create a [VisibilityDetectorLayer].  However, in case one
+      // already exists, remove all cached data for it so that we won't fire
+      // visibility callbacks when the layer is removed.
+      VisibilityDetectorLayer.forget(key);
+      super.paint(context, offset);
+      return;
+    }
+
+    final layer = VisibilityDetectorLayer(
+        key: key,
+        widgetSize: semanticBounds.size,
+        paintOffset: offset,
+        onVisibilityChanged: onVisibilityChanged!);
+    context.pushLayer(layer, super.paint, offset);
+  }
+}

--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -57,7 +57,7 @@ class RenderVisibilityDetector extends RenderProxyBox {
 
     final layer = VisibilityDetectorLayer(
         key: key,
-        widgetSize: semanticBounds.size,
+        widgetRect: Offset.zero & semanticBounds.size,
         paintOffset: offset,
         onVisibilityChanged: onVisibilityChanged!);
     context.pushLayer(layer, super.paint, offset);

--- a/packages/visibility_detector/lib/src/visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector.dart
@@ -60,7 +60,6 @@ class VisibilityDetector extends SingleChildRenderObjectWidget {
   }
 }
 
-/// Sliver version of [VisibilityDetector].
 class SliverVisibilityDetector extends SingleChildRenderObjectWidget {
   /// Constructor.
   ///
@@ -191,6 +190,11 @@ class VisibilityInfo {
     // if other properties are added.
     assert(info != null);
     return size == info.size && visibleBounds == info.visibleBounds;
+  }
+
+  @override
+  String toString() {
+    return 'VisibilityInfo(size: $size visibleBounds: $visibleBounds)';
   }
 }
 

--- a/packages/visibility_detector/lib/src/visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector.dart
@@ -9,6 +9,7 @@ import 'dart:math' show max;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'render_sliver_visibility_detector.dart';
 import 'render_visibility_detector.dart';
 
 /// A [VisibilityDetector] widget fires a specified callback when the widget
@@ -54,6 +55,46 @@ class VisibilityDetector extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(
       BuildContext context, RenderVisibilityDetector renderObject) {
+    assert(renderObject.key == key);
+    renderObject.onVisibilityChanged = onVisibilityChanged;
+  }
+}
+
+/// Sliver version of [VisibilityDetector].
+class SliverVisibilityDetector extends SingleChildRenderObjectWidget {
+  /// Constructor.
+  ///
+  /// `key` is required to properly identify this widget; it must be unique
+  /// among all [VisibilityDetector] and [SliverVisibilityDetector] widgets.
+  ///
+  /// `child` must not be null.
+  ///
+  /// `onVisibilityChanged` may be null to disable this
+  /// [SliverVisibilityDetector].
+  const SliverVisibilityDetector({
+    required Key key,
+    required Widget sliver,
+    required this.onVisibilityChanged,
+  })   : assert(key != null),
+        assert(sliver != null),
+        super(key: key, child: sliver);
+
+  /// The callback to invoke when this widget's visibility changes.
+  final VisibilityChangedCallback? onVisibilityChanged;
+
+  /// See [RenderObjectWidget.createRenderObject].
+  @override
+  RenderSliverVisibilityDetector createRenderObject(BuildContext context) {
+    return RenderSliverVisibilityDetector(
+      key: key!,
+      onVisibilityChanged: onVisibilityChanged,
+    );
+  }
+
+  /// See [RenderObjectWidget.updateRenderObject].
+  @override
+  void updateRenderObject(
+      BuildContext context, RenderSliverVisibilityDetector renderObject) {
     assert(renderObject.key == key);
     renderObject.onVisibilityChanged = onVisibilityChanged;
   }

--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -62,12 +62,12 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Constructor.  See the corresponding properties for parameter details.
   VisibilityDetectorLayer(
       {required this.key,
-      required this.widgetSize,
+      required this.widgetRect,
       required this.paintOffset,
       required this.onVisibilityChanged})
       : assert(key != null),
         assert(paintOffset != null),
-        assert(widgetSize != null),
+        assert(widgetRect != null),
         assert(onVisibilityChanged != null),
         _layerOffset = Offset.zero;
 
@@ -98,8 +98,8 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// The key for the corresponding [VisibilityDetector] widget.
   final Key key;
 
-  /// The size of the corresponding [VisibilityDetector] widget.
-  final Size widgetSize;
+  /// The bounds of the corresponding [VisibilityDetector] widget.
+  final Rect widgetRect;
 
   /// Last known layer offset supplied to [addToScene].
   Offset _layerOffset;
@@ -115,7 +115,7 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Computes the bounds for the corresponding [VisibilityDetector] widget, in
   /// global coordinates.
   Rect _computeWidgetBounds() {
-    final r = _localRectToGlobal(this, Offset.zero & widgetSize);
+    final r = _localRectToGlobal(this, widgetRect);
     return r.shift(paintOffset + _layerOffset);
   }
 

--- a/packages/visibility_detector/test/widget_test.dart
+++ b/packages/visibility_detector/test/widget_test.dart
@@ -44,9 +44,8 @@ void main() {
     'VisibilityDetector reports initial visibility',
     callback: (tester) async {
       final cellKey = demo.cellKey(0, 0);
-      final cell = find.byKey(cellKey);
-      final expectedRect = tester.getRect(cell);
-
+      final expectedRect =
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 0)];
       expect(info, isNotNull);
 
@@ -72,11 +71,12 @@ void main() {
       final viewRect = tester.getRect(mainList);
 
       final cellKey = demo.cellKey(0, 0);
-      final cell = find.byKey(cellKey);
-      final originalRect = tester.getRect(cell);
+      final originalRect =
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
 
       const dy = 30.0;
-      await _doScroll(tester, mainList, const Offset(0, dy));
+      await _doScroll(tester, find.byKey(demo.secondaryScrollableKey(0)),
+          const Offset(0, dy));
 
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 0)];
       expect(info, isNotNull);
@@ -107,14 +107,13 @@ void main() {
       final viewRect = tester.getRect(mainList);
 
       final cellKey = demo.cellKey(2, 0);
-      final cell = find.byKey(cellKey);
-      expect(cell, findsOneWidget);
-      final originalRect = tester.getRect(cell);
-
+      final originalRect =
+          tester.getRect(find.byKey(demo.cellContentKey(2, 0)));
       const dx = 30.0;
       expect(dx < originalRect.width, true);
 
-      await _doScroll(tester, cell, const Offset(dx, 0));
+      final row = find.byKey(demo.secondaryScrollableKey(2));
+      await _doScroll(tester, row, const Offset(dx, 0));
 
       var info = _positionToVisibilityInfo[demo.RowColumn(2, 0)];
       expect(info, isNotNull);
@@ -146,8 +145,8 @@ void main() {
       final viewRect = tester.getRect(mainList);
 
       final cellKey = demo.cellKey(0, 0);
-      final cell = find.byKey(cellKey);
-      final originalRect = tester.getRect(cell);
+      final originalRect =
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
 
       final dy = originalRect.bottom - viewRect.top;
       await _doScroll(tester, mainList, Offset(0, dy));
@@ -175,11 +174,13 @@ void main() {
       final viewRect = tester.getRect(mainList);
 
       final cellKey = demo.cellKey(0, 0);
-      final cell = find.byKey(cellKey);
-      final originalRect = tester.getRect(cell);
+      final originalRect =
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
 
       final dy = (originalRect.bottom - viewRect.top) - 1;
-      await _doScroll(tester, mainList, Offset(0, dy));
+
+      await _doScroll(
+          tester, find.byKey(demo.secondaryScrollableKey(0)), Offset(0, dy));
 
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 0)];
       expect(info, isNotNull);
@@ -204,8 +205,8 @@ void main() {
     'tree',
     callback: (tester) async {
       final cellKey = demo.cellKey(0, 0);
-      final cell = find.byKey(cellKey);
-      final originalRect = tester.getRect(cell);
+      final originalRect =
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
 
       await _clearWidgetTree(tester, notifyNow: false);
 
@@ -377,7 +378,9 @@ void _wrapTest(
     // widget tree is destroyed, which is too late for our purposes. (See
     // details below.)
     await _initWidgetTree(
-        widget ?? const demo.VisibilityDetectorDemo(), tester);
+      widget ?? demo.VisibilityDetectorDemo(useSlivers: false),
+      tester,
+    );
     await callback(tester);
 
     /// When the test destroys the widget tree with [VisibilityDetector] widgets
@@ -389,6 +392,16 @@ void _wrapTest(
     /// flush those [Timer] objects. (See https://github.com/flutter/flutter/issues/24166.)
     /// Instead we must explicitly clear the widget tree ourselves and wait for
     /// callbacks to fire before ending the test.
+    await _clearWidgetTree(tester);
+  });
+
+  // Test one more time using slivers version of the demo.
+  testWidgets(description, (tester) async {
+    await _initWidgetTree(
+      widget ?? demo.VisibilityDetectorDemo(useSlivers: true),
+      tester,
+    );
+    await callback(tester);
     await _clearWidgetTree(tester);
   });
 }


### PR DESCRIPTION
## Description

Added a SliverVisibilityDetector for sliver widgets.

For the demo: added a toggle to switch between 4 layouts (row-column/column-row, and reverse direction), and a toggle to switch between RenderBox and RenderSliver widgets.

For the tests: run the test cases on both kinds of widgets.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
