### PR TITLE
flutter_simple_treeview: replaced IconButton by placeholder when node has no children

### DIFF
--- a/packages/flutter_simple_treeview/lib/src/node_widget.dart
+++ b/packages/flutter_simple_treeview/lib/src/node_widget.dart
@@ -17,13 +17,13 @@ class NodeWidget extends StatefulWidget {
   final double? iconSize;
   final TreeController state;
 
-  const NodeWidget(
-      {Key? key,
-      required this.treeNode,
-      this.indent,
-      required this.state,
-      this.iconSize})
-      : super(key: key);
+  const NodeWidget({
+    Key? key,
+    required this.treeNode,
+    this.indent,
+    required this.state,
+    this.iconSize,
+  }) : super(key: key);
 
   @override
   _NodeWidgetState createState() => _NodeWidgetState();
@@ -39,29 +39,32 @@ class _NodeWidgetState extends State<NodeWidget> {
     return widget.state.isNodeExpanded(widget.treeNode.key!);
   }
 
+  Widget buildButtonOrPlaceholder() {
+    var icon = _isExpanded ? Icons.expand_more : Icons.chevron_right;
+    double defaultSize = 24;
+    double widgetSize = widget.iconSize ?? defaultSize;
+    return _isLeaf
+        ? SizedBox(
+            key: Key('NodeWidget.Spacer'),
+            width: widgetSize,
+          )
+        : IconButton(
+            key: Key('NodeWidget.IconButton'),
+            iconSize: widgetSize,
+            icon: Icon(icon),
+            onPressed: () =>
+                widget.state.toggleNodeExpanded(widget.treeNode.key!),
+          );
+  }
+
   @override
   Widget build(BuildContext context) {
-    var icon = _isLeaf
-        ? null
-        : _isExpanded
-            ? Icons.expand_more
-            : Icons.chevron_right;
-
-    var onIconPressed = _isLeaf
-        ? null
-        : () => setState(
-            () => widget.state.toggleNodeExpanded(widget.treeNode.key!));
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
           children: [
-            IconButton(
-              iconSize: widget.iconSize ?? 24.0,
-              icon: Icon(icon),
-              onPressed: onIconPressed,
-            ),
+            buildButtonOrPlaceholder(),
             widget.treeNode.content,
           ],
         ),

--- a/packages/flutter_simple_treeview/lib/src/node_widget.dart
+++ b/packages/flutter_simple_treeview/lib/src/node_widget.dart
@@ -52,8 +52,9 @@ class _NodeWidgetState extends State<NodeWidget> {
             key: Key('NodeWidget.IconButton'),
             iconSize: widgetSize,
             icon: Icon(icon),
-            onPressed: () =>
-                widget.state.toggleNodeExpanded(widget.treeNode.key!),
+            onPressed: () => setState(
+              () => widget.state.toggleNodeExpanded(widget.treeNode.key!),
+            ),
           );
   }
 

--- a/packages/flutter_simple_treeview/lib/src/node_widget.dart
+++ b/packages/flutter_simple_treeview/lib/src/node_widget.dart
@@ -42,20 +42,24 @@ class _NodeWidgetState extends State<NodeWidget> {
   Widget buildButtonOrPlaceholder() {
     var icon = _isExpanded ? Icons.expand_more : Icons.chevron_right;
     double defaultSize = 24;
-    double widgetSize = widget.iconSize ?? defaultSize;
+    double iconSize = widget.iconSize ?? defaultSize;
+
+    IconButton iconButton = IconButton(
+      key: Key('NodeWidget.IconButton'),
+      iconSize: iconSize,
+      icon: Icon(icon),
+      onPressed: () => setState(
+        () => widget.state.toggleNodeExpanded(widget.treeNode.key!),
+      ),
+    );
+    double spacerSize = iconSize + iconButton.padding.horizontal;
+
     return _isLeaf
         ? SizedBox(
             key: Key('NodeWidget.Spacer'),
-            width: widgetSize,
+            width: spacerSize,
           )
-        : IconButton(
-            key: Key('NodeWidget.IconButton'),
-            iconSize: widgetSize,
-            icon: Icon(icon),
-            onPressed: () => setState(
-              () => widget.state.toggleNodeExpanded(widget.treeNode.key!),
-            ),
-          );
+        : iconButton;
   }
 
   @override

--- a/packages/flutter_simple_treeview/test/tree_view_test.dart
+++ b/packages/flutter_simple_treeview/test/tree_view_test.dart
@@ -54,6 +54,28 @@ void main() {
       }
     });
 
+    testWidgets(
+        'renders one IconButton and one Spacer when a root with one child exists.',
+        (WidgetTester tester) async {
+      var widget = TreeView(
+        nodes: [
+          TreeNode(
+            content: Text('root'),
+            children: [
+              TreeNode(content: Text('child')),
+            ],
+          ),
+        ],
+      );
+
+      await _wrapAndPump(tester, widget);
+
+      var iconButtonFinder = find.byKey(Key('NodeWidget.IconButton'));
+      var spacerFinder = find.byKey(Key('NodeWidget.IconButton'));
+      expect(iconButtonFinder, findsOneWidget);
+      expect(spacerFinder, findsOneWidget);
+    });
+
     test('generates unique key if the key is null.', () {
       var tree = TreeView(nodes: [
         TreeNode(),

--- a/packages/flutter_simple_treeview/test/tree_view_test.dart
+++ b/packages/flutter_simple_treeview/test/tree_view_test.dart
@@ -76,6 +76,31 @@ void main() {
       expect(spacerFinder, findsOneWidget);
     });
 
+    testWidgets('renders equal size for IconButton and Spacer.',
+        (WidgetTester tester) async {
+      var widget = TreeView(
+        nodes: [
+          TreeNode(
+            content: Text('root'),
+            children: [
+              TreeNode(content: Text('child')),
+            ],
+          ),
+        ],
+      );
+
+      await _wrapAndPump(tester, widget);
+
+      var iconButtonFinder = find.byKey(Key('NodeWidget.IconButton'));
+      var spacerFinder = find.byKey(Key('NodeWidget.IconButton'));
+      expect(
+        tester.getSize(iconButtonFinder),
+        equals(
+          tester.getSize(spacerFinder),
+        ),
+      );
+    });
+
     test('generates unique key if the key is null.', () {
       var tree = TreeView(nodes: [
         TreeNode(),


### PR DESCRIPTION
## Description
In the current version the mouse cursor changes to a _clickable_ cursor if it is hovered over the leading widget of the `TreeNode`.  This is due to an IconButton that is rendered without `IconData` making it invisible to see. 

The fix replaces the `IconButton` with a `SizedBox` if the `NodeWidget` is a leaf node. Therefore, the mouse cursor does not change the a _clickable_ cursor if the area leading `TreeNode.content` is hovered.

## Related Issues
#244 

## Checklist

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
