### PR TITLE
Make tool/travis.sh use `flutter format` instead of `dartfmt`, disable a useless lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,7 +36,7 @@ linter:
     - library_names
     - library_prefixes
     - list_remove_unrelated_type
-    - literal_only_boolean_expressions
+    #- literal_only_boolean_expressions # https://github.com/dart-lang/linter/issues/453
     - non_constant_identifier_names
     - one_member_abstracts
     - only_throw_errors
@@ -46,7 +46,7 @@ linter:
     - package_prefixed_library_names
     - prefer_is_not_empty
     - slash_for_doc_comments
-    # TODO - sort_constructors_first
+    #- sort_constructors_first
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/packages/visibility_detector/example/lib/main.dart
+++ b/packages/visibility_detector/example/lib/main.dart
@@ -520,7 +520,6 @@ Iterable<T> collate<T>(Iterable<Iterable<T>> iterables) sync* {
     return;
   }
 
-  // ignore: literal_only_boolean_expressions, https://github.com/dart-lang/linter/issues/453
   while (true) {
     var exhaustedCount = 0;
     for (final i in iterators) {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -5,15 +5,9 @@ set -e
 
 shopt -s globstar nullglob
 
-# Make sure dartfmt is run on everything
-echo "Checking dartfmt..."
-NEEDS_DARTFMT="$(dartfmt -n packages tool)"
-if [[ "${NEEDS_DARTFMT}" != "" ]]
-then
-  echo "FAILED"
-  echo "${NEEDS_DARTFMT}"
-  exit 1
-fi
+# Make sure the formatter is run on everything
+echo "Checking formatting..."
+flutter format --dry-run --set-exit-if-changed packages tool
 echo "PASSED"
 echo
 


### PR DESCRIPTION
The `dartfmt` command has been replaced with `dart format`.

We currently can't quite replace `dartfmt` with `dart format` because the fix for https://github.com/dart-lang/sdk/issues/44582 hasn't reached the Flutter beta channel yet, so we can't rely on its exit code.  Additionally, unlike `dartfmt --dry-run`, `dart format
--output=none` prints status to stdout even if nothing's changed, so we can no longer rely on the output being empty either.

Luckily, `flutter format` does return a proper exit code, so use that.

Also, disable the `literal_only_boolean_expressions` lint. I don't see any value in it, and it's already banned internally.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
