### PR TITLE
fix #173

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -308,6 +308,7 @@ class _PositionedListState extends State<PositionedList> {
           final ValueKey<int> key = element.widget.key as ValueKey<int>;
           if (widget.scrollDirection == Axis.vertical) {
             final reveal = viewport!.getOffsetToReveal(box, 0).offset;
+            if (!reveal.isFinite) continue;
             final itemOffset = reveal -
                 viewport.offset.pixels +
                 viewport.anchor * viewport.size.height;


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

to fix `Infinity or NaN toInt` error caused by `reveal` value
thanks for #180 

This is a simple bug fix that prevent scrolling crash because of Infinity or NaN toInt converting.

<!--
Replace this with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).
-->
*TODO*

## Related Issues
#173 
<!--
Replace this with a list of issues related to this PR. Indicate which of these issues are resolved or fixed by this PR.
-->
*TODO*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
