### PR TITLE
Add ability to provide initialScrollOffset

### DIFF
--- a/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
+++ b/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
@@ -20,11 +20,15 @@ import 'package:flutter/rendering.dart';
 /// Without the keys, Flutter may reuse a controller after it has been disposed,
 /// which can cause the controller offsets to fall out of sync.
 class LinkedScrollControllerGroup {
-  LinkedScrollControllerGroup() {
+  LinkedScrollControllerGroup({double? initialScrollOffset}) {
+    _initialScrollOffset =
+        initialScrollOffset == null ? 0.0 : initialScrollOffset;
     _offsetNotifier = _LinkedScrollControllerGroupOffsetNotifier(this);
   }
 
   final _allControllers = <_LinkedScrollController>[];
+
+  late double _initialScrollOffset;
 
   late _LinkedScrollControllerGroupOffsetNotifier _offsetNotifier;
 
@@ -41,7 +45,7 @@ class LinkedScrollControllerGroup {
   /// Creates a new controller that is linked to any existing ones.
   ScrollController addAndGet() {
     final initialScrollOffset = _attachedControllers.isEmpty
-        ? 0.0
+        ? _initialScrollOffset
         : _attachedControllers.first.position.pixels;
     final controller =
         _LinkedScrollController(this, initialScrollOffset: initialScrollOffset);

--- a/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
+++ b/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
@@ -310,6 +310,33 @@ void main() {
       expect(state._controllers.offset, equals(state._letters.offset));
       expect(state._controllers.offset, equals(state._numbers.offset));
     });
+
+    testWidgets('should have 0 offset by default', (tester) async {
+      await tester.pumpWidget(Test());
+      final state = tester.state<TestState>(find.byType(Test));
+
+      expect(state._letters.position.pixels, 0.0);
+      expect(state._numbers.position.pixels, 0.0);
+    });
+
+    testWidgets('should have 0 offset when initialScrollOffset is null',
+        (tester) async {
+      await tester.pumpWidget(Test(initialScrollOffset: null));
+      final state = tester.state<TestState>(find.byType(Test));
+
+      expect(state._letters.position.pixels, 0.0);
+      expect(state._numbers.position.pixels, 0.0);
+    });
+
+    testWidgets(
+        'should have specified offset when initialScrollOffset is given',
+        (tester) async {
+      await tester.pumpWidget(Test(initialScrollOffset: 20));
+      final state = tester.state<TestState>(find.byType(Test));
+
+      expect(state._letters.position.pixels, 20.0);
+      expect(state._numbers.position.pixels, 20.0);
+    });
   });
 }
 
@@ -334,6 +361,12 @@ class TestEmptyGroupState extends State<TestEmptyGroup> {
 }
 
 class Test extends StatefulWidget {
+  late final double? _initialScrollOffset;
+
+  Test({double? initialScrollOffset = -1}) {
+    _initialScrollOffset = initialScrollOffset;
+  }
+
   @override
   TestState createState() => TestState();
 }
@@ -347,7 +380,10 @@ class TestState extends State<Test> {
   @override
   void initState() {
     super.initState();
-    _controllers = LinkedScrollControllerGroup();
+    _controllers = widget._initialScrollOffset == -1
+        ? LinkedScrollControllerGroup()
+        : LinkedScrollControllerGroup(
+            initialScrollOffset: widget._initialScrollOffset);
     _letters = _controllers.addAndGet();
     _numbers = _controllers.addAndGet();
   }


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

<!--
Replace this with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).
-->
Added ability to initially provide `initialScrollOffset` so that you would not need to wait for scroll controllers to get attached to their widgets and only then call `jumpTo` to set the offset. Instead, now you can simply do:
```
LinkedScrollControllerGroup(
    initialScrollOffset: 20,
);
```

## Related Issues

<!--
Replace this with a list of issues related to this PR. Indicate which of these issues are resolved or fixed by this PR.
-->
Not related to any existing issues.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
