### PR TITLE
Bug fix for using VisibilityDetector with FittedBox and Transform.scale.

### DIFF
--- a/packages/visibility_detector/CHANGELOG.md
+++ b/packages/visibility_detector/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1
+
+* Bug fix for using VisibilityDetector with FittedBox and Transform.scale [issue #285](https://github.com/google/flutter.widgets/issues/285).
+
 # 0.2.0
 
 * Added `SliverVisibilityDetector` to report visibility of `RenderSliver`-based

--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -122,7 +122,7 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Computes the bounds for the corresponding [VisibilityDetector] widget, in
   /// global coordinates.
   Rect _computeWidgetBounds() {
-    final r = _localRectToGlobal(this, (widgetOffset & widgetSize).shift(paintOffset));
+    final r = _localRectToGlobal(this, (paintOffset + widgetOffset & widgetSize));
     return r.shift(_layerOffset);
   }
 

--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -122,7 +122,7 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Computes the bounds for the corresponding [VisibilityDetector] widget, in
   /// global coordinates.
   Rect _computeWidgetBounds() {
-    final r = _localRectToGlobal(this, (paintOffset + widgetOffset & widgetSize));
+    final r = _localRectToGlobal(this, paintOffset + widgetOffset & widgetSize);
     return r.shift(_layerOffset);
   }
 

--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -122,8 +122,8 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Computes the bounds for the corresponding [VisibilityDetector] widget, in
   /// global coordinates.
   Rect _computeWidgetBounds() {
-    final r = _localRectToGlobal(this, widgetOffset & widgetSize);
-    return r.shift(paintOffset + _layerOffset);
+    final r = _localRectToGlobal(this, (widgetOffset & widgetSize).shift(paintOffset));
+    return r.shift(_layerOffset);
   }
 
   /// Computes the accumulated clipping bounds, in global coordinates.

--- a/packages/visibility_detector/pubspec.yaml
+++ b/packages/visibility_detector/pubspec.yaml
@@ -1,5 +1,5 @@
 name: visibility_detector
-version: 0.2.0
+version: 0.2.1
 description: >
     A widget that detects the visibility of its child
     and notifies a callback.

--- a/packages/visibility_detector/test/widget_test.dart
+++ b/packages/visibility_detector/test/widget_test.dart
@@ -44,7 +44,7 @@ void main() {
     callback: (tester) async {
       final cellKey = demo.cellKey(0, 0);
       final expectedRect =
-      tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
+          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 0)];
       expect(info, isNotNull);
 
@@ -56,7 +56,7 @@ void main() {
       expect(info.visibleFraction, 1.0);
 
       final bounds =
-      VisibilityDetectorController.instance.widgetBoundsFor(cellKey);
+          VisibilityDetectorController.instance.widgetBoundsFor(cellKey);
       expect(bounds, expectedRect);
     },
   );
@@ -66,8 +66,8 @@ void main() {
     callback: (tester) async {
       final scaleButton = find.byKey(demo.scaleButtonKey);
       await tester.tap(scaleButton);
-      await tester.pumpAndSettle();
-      await _doStateChange(tester, () { });
+      await tester.pump();
+      await tester.pump(VisibilityDetectorController.instance.updateInterval);
 
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 1)];
       expect(info, isNotNull);
@@ -496,7 +496,9 @@ class _TestPropertyChangeState extends State<_TestPropertyChange> {
   /// Whether our [VisibilityDetector] should be enabled (i.e., whether it
   /// should fire visibility callbacks).
   bool _visibilityDetectorEnabled = true;
+
   bool get visibilityDetectorEnabled => _visibilityDetectorEnabled;
+
   set visibilityDetectorEnabled(bool value) {
     setState(() {
       _visibilityDetectorEnabled = value;
@@ -505,11 +507,13 @@ class _TestPropertyChangeState extends State<_TestPropertyChange> {
 
   /// The last reported visibility of our [VisibilityDetector].
   double _lastVisibleFraction = 0;
+
   double get lastVisibleFraction => _lastVisibleFraction;
 
   /// The number of times that our [VisibilityDetector]'s callback has been
   /// triggered.
   int _callbackCount = 0;
+
   int get callbackCount => _callbackCount;
 
   /// [VisibilityDetector] callback for when the visibility of the widget

--- a/packages/visibility_detector/test/widget_test.dart
+++ b/packages/visibility_detector/test/widget_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:visibility_detector/visibility_detector.dart';
-
 import 'package:visibility_detector_example/main.dart' as demo;
 
 /// Maps [row, column] indices to the last reported [VisibilityInfo] for the
@@ -45,7 +44,7 @@ void main() {
     callback: (tester) async {
       final cellKey = demo.cellKey(0, 0);
       final expectedRect =
-          tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
+      tester.getRect(find.byKey(demo.cellContentKey(0, 0)));
       var info = _positionToVisibilityInfo[demo.RowColumn(0, 0)];
       expect(info, isNotNull);
 
@@ -57,8 +56,24 @@ void main() {
       expect(info.visibleFraction, 1.0);
 
       final bounds =
-          VisibilityDetectorController.instance.widgetBoundsFor(cellKey);
+      VisibilityDetectorController.instance.widgetBoundsFor(cellKey);
       expect(bounds, expectedRect);
+    },
+  );
+
+  _wrapTest(
+    'VisibilityDetector test with transform.scale',
+    callback: (tester) async {
+      final scaleButton = find.byKey(demo.scaleButtonKey);
+      await tester.tap(scaleButton);
+      await tester.pumpAndSettle();
+      await _doStateChange(tester, () { });
+
+      var info = _positionToVisibilityInfo[demo.RowColumn(0, 1)];
+      expect(info, isNotNull);
+
+      info = info!;
+      expect(info.visibleFraction, 1.0);
     },
   );
 


### PR DESCRIPTION
## Description

This is a bug fix for an existing function. The VisibilityDetector did not work correctly with widgets that change the scale because it used an offset after the scaling was applied instead of before the scaling was applied. It seems to work fine with this change. I use it in my app now (but I have backported it and use it with Flutter 1.17 because Flutter 2.x does not work correctly in Firefox on Android yet).

## Related Issues

https://github.com/google/flutter.widgets/issues/283

## Checklist

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
