### PR TITLE
Remove unused layerOffset

### DIFF
--- a/packages/visibility_detector/CHANGELOG.md
+++ b/packages/visibility_detector/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2
+
+* Minor internal changes to maintain forward-compatibility with [flutter#91753](https://github.com/flutter/flutter/pull/91753).
+
 # 0.2.1
 
 * Bug fix for using VisibilityDetector with FittedBox and Transform.scale [issue #285](https://github.com/google/flutter.widgets/issues/285).

--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -69,8 +69,7 @@ class VisibilityDetectorLayer extends ContainerLayer {
       : assert(key != null),
         assert(paintOffset != null),
         assert(widgetSize != null),
-        assert(onVisibilityChanged != null),
-        _layerOffset = Offset.zero;
+        assert(onVisibilityChanged != null);
 
   /// Timer used by [_scheduleUpdate].
   static Timer? _timer;
@@ -108,9 +107,6 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// The size of the corresponding [VisibilityDetector] widget.
   final Size widgetSize;
 
-  /// Last known layer offset supplied to [addToScene].
-  Offset _layerOffset;
-
   /// The offset supplied to [RenderVisibilityDetector.paint] method.
   final Offset paintOffset;
 
@@ -122,8 +118,7 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// Computes the bounds for the corresponding [VisibilityDetector] widget, in
   /// global coordinates.
   Rect _computeWidgetBounds() {
-    final r = _localRectToGlobal(this, paintOffset + widgetOffset & widgetSize);
-    return r.shift(_layerOffset);
+    return _localRectToGlobal(this, paintOffset + widgetOffset & widgetSize);
   }
 
   /// Computes the accumulated clipping bounds, in global coordinates.
@@ -271,9 +266,11 @@ class VisibilityDetectorLayer extends ContainerLayer {
   /// See [Layer.addToScene].
   @override
   void addToScene(ui.SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
-    _layerOffset = layerOffset;
+    // TODO(goderbauer): Remove unused layerOffset parameter once
+    //     https://github.com/flutter/flutter/pull/91753 is in stable.
+    assert(layerOffset == Offset.zero);
     _scheduleUpdate();
-    super.addToScene(builder, layerOffset);
+    super.addToScene(builder);
   }
 
   /// See [AbstractNode.attach].

--- a/packages/visibility_detector/pubspec.yaml
+++ b/packages/visibility_detector/pubspec.yaml
@@ -1,5 +1,5 @@
 name: visibility_detector
-version: 0.2.1
+version: 0.2.2
 description: >
     A widget that detects the visibility of its child
     and notifies a callback.


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/91753 will remove the unused `layerOffset` parameter from `Layer.addToScene` in Flutter. This change maintains forward-compatibility with that change.

## Related Issues

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
