### PR TITLE
adds initialOffset and tests

### DIFF
--- a/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
+++ b/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
@@ -20,7 +20,10 @@ import 'package:flutter/rendering.dart';
 /// Without the keys, Flutter may reuse a controller after it has been disposed,
 /// which can cause the controller offsets to fall out of sync.
 class LinkedScrollControllerGroup {
-  LinkedScrollControllerGroup() {
+  /// Sets the initial offset for all controllers created by this group.
+  final double initialOffset;
+
+  LinkedScrollControllerGroup({this.initialOffset = 0.0}) {
     _offsetNotifier = _LinkedScrollControllerGroupOffsetNotifier(this);
   }
 
@@ -41,7 +44,7 @@ class LinkedScrollControllerGroup {
   /// Creates a new controller that is linked to any existing ones.
   ScrollController addAndGet() {
     final initialScrollOffset = _attachedControllers.isEmpty
-        ? 0.0
+        ? initialOffset
         : _attachedControllers.first.position.pixels;
     final controller =
         _LinkedScrollController(this, initialScrollOffset: initialScrollOffset);

--- a/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
+++ b/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
@@ -161,6 +161,28 @@ void main() {
       expect(state._controllers.offset, equals(state._letters.offset));
     });
 
+    testWidgets('initialOffset within range', (tester) async {
+      await tester.pumpWidget(Test(initialOffset: 300.0));
+
+      final state = tester.state<TestState>(find.byType(Test));
+      expect(state._controllers.offset, equals(300.0));
+    });
+
+    testWidgets('initialOffset out of range', (tester) async {
+      await tester.pumpWidget(Test(initialOffset: 1000.0));
+
+      final state = tester.state<TestState>(find.byType(Test));
+      expect(state._controllers.offset, equals(1000.0));
+      
+      // waiting for ballistic activity
+      await tester.pumpAndSettle();
+
+      final state2 = tester.state<TestState>(find.byType(Test));
+      // max scroll extent is
+      // widgets height - window height = 266 * 5 - 600 = 1330 - 600 = 730
+      expect(state2._controllers.offset, equals(730.0));
+    });
+
     testWidgets('onOffsetChanged fires on scroll', (tester) async {
       await tester.pumpWidget(Test());
       final state = tester.state<TestState>(find.byType(Test));
@@ -334,6 +356,9 @@ class TestEmptyGroupState extends State<TestEmptyGroup> {
 }
 
 class Test extends StatefulWidget {
+  final double initialOffset;
+
+  const Test({this.initialOffset = 0.0});
   @override
   TestState createState() => TestState();
 }
@@ -347,7 +372,7 @@ class TestState extends State<Test> {
   @override
   void initState() {
     super.initState();
-    _controllers = LinkedScrollControllerGroup();
+    _controllers = LinkedScrollControllerGroup(initialOffset: widget.initialOffset);
     _letters = _controllers.addAndGet();
     _numbers = _controllers.addAndGet();
   }


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description
Enables users to set initial offset to `LinkedScrollControllerGroup`.

Code Sample:
```dart
LinkedScrollControllerGroup controllers = LinkedScrollControllerGroup(initialOffset: -100);
```

## Related Issues
#267 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
