### PR TITLE
[scrollable_positioned_list] Expose ScrollController to be observed by Scrollbar

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -168,6 +168,15 @@ class ScrollablePositionedList extends StatefulWidget {
 /// Controller to jump or scroll to a particular position in a
 /// [ScrollablePositionedList].
 class ItemScrollController {
+
+  ItemScrollController({ ScrollController? scrollController }) {
+    this.scrollController = scrollController ?? ScrollController(keepScrollOffset: false);
+  }
+
+  /// Exposes [ScrollablePositionedList]'s Primary scroll controller
+  ///
+  ScrollController? scrollController;
+
   /// Whether any ScrollablePositionedList objects are attached this object.
   ///
   /// If `false`, then [jumpTo] and [scrollTo] must not be called.
@@ -248,11 +257,11 @@ class ItemScrollController {
 class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     with TickerProviderStateMixin {
   /// Details for the primary (active) [ListView].
-  var primary = _ListDisplayDetails(const ValueKey('Ping'));
+  late _ListDisplayDetails primary;
 
   /// Details for the secondary (transitional) [ListView] that is temporarily
   /// shown when scrolling a long distance.
-  var secondary = _ListDisplayDetails(const ValueKey('Pong'));
+  late _ListDisplayDetails secondary;
 
   final opacity = ProxyAnimation(const AlwaysStoppedAnimation<double>(0));
 
@@ -264,6 +273,8 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
   void initState() {
     super.initState();
     ItemPosition? initialPosition = PageStorage.of(context)!.readState(context);
+    primary = _ListDisplayDetails(const ValueKey('Ping'),  widget.itemScrollController?.scrollController ?? ScrollController(keepScrollOffset: false));
+    secondary = _ListDisplayDetails(const ValueKey('Pong'), ScrollController(keepScrollOffset: false));
     primary.target = initialPosition?.index ?? widget.initialScrollIndex;
     primary.alignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
@@ -561,10 +572,10 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
 }
 
 class _ListDisplayDetails {
-  _ListDisplayDetails(this.key);
+  _ListDisplayDetails(this.key, this.scrollController);
 
   final itemPositionsNotifier = ItemPositionsNotifier();
-  final scrollController = ScrollController(keepScrollOffset: false);
+  final ScrollController scrollController;
 
   /// The index of the item to scroll to.
   int target = 0;


### PR DESCRIPTION
## Description


This PR exposes the primary listview's  scrollController inside the ScrollablePositionedList  from the ItemScrollController so that it can be observer by ScrollBars.

This also allows passing the scrollController to the ItemScrollController.

As a result we will finally be able to use like this
```
    Scrollbar(
        thickness: 8,
        radius: Radius.circular(4),
        controller: itemScrollController.scrollController,
        child: ScrollablePositionedList.builder(
              itemCount: totalItems,
              itemScrollController: itemScrollController,
              itemBuilder: (context, index) {
                return Container(
                    color: getItemColor(index, context),
                    child: buildDropdownList(context, index),
                );
              },
          ),
     )

```

## Related Issues

#273 
#303 
#278 
#235 
#175 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

