### PR TITLE
Do not pass on overscroll to peers

### DIFF
--- a/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
+++ b/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
@@ -247,6 +247,10 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     if (newPixels == pixels) {
       return 0.0;
     }
+    // Detect overscroll
+    if (newPixels > maxScrollExtent) {
+      newPixels = maxScrollExtent;
+    }
     updateUserScrollDirection(newPixels - pixels > 0.0
         ? ScrollDirection.forward
         : ScrollDirection.reverse);
@@ -254,20 +258,14 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     if (owner.canLinkWithPeers) {
       _peerActivities.addAll(owner.linkWithPeers(this));
       for (var activity in _peerActivities) {
-        activity.moveTo(newPixels, maxScrollExtent);
+        activity.moveTo(newPixels);
       }
     }
 
-    return setPixelsInternal(newPixels, maxScrollExtent);
+    return setPixelsInternal(newPixels);
   }
 
-  double setPixelsInternal(double newPixels, double sourceMaxScrollExtent) {
-    // If we have scroll views of different heights and overscroll, we do not
-    // want that overscroll to be passed on to the peers. So, we make sure to
-    // not scroll beyond the `maxScrollExtent` of the source scroll view.
-    if (newPixels > sourceMaxScrollExtent) {
-      newPixels = sourceMaxScrollExtent;
-    }
+  double setPixelsInternal(double newPixels) {
     return super.setPixels(newPixels);
   }
 
@@ -351,9 +349,9 @@ class _LinkedScrollActivity extends ScrollActivity {
   @override
   double get velocity => 0.0;
 
-  void moveTo(double newPixels, sourceMaxScrollExtent) {
+  void moveTo(double newPixels) {
     _updateUserScrollDirection();
-    delegate.setPixelsInternal(newPixels, sourceMaxScrollExtent);
+    delegate.setPixelsInternal(newPixels);
   }
 
   void jumpTo(double newPixels) {

--- a/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
+++ b/packages/linked_scroll_controller/lib/linked_scroll_controller.dart
@@ -254,14 +254,20 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     if (owner.canLinkWithPeers) {
       _peerActivities.addAll(owner.linkWithPeers(this));
       for (var activity in _peerActivities) {
-        activity.moveTo(newPixels);
+        activity.moveTo(newPixels, maxScrollExtent);
       }
     }
 
-    return setPixelsInternal(newPixels);
+    return setPixelsInternal(newPixels, maxScrollExtent);
   }
 
-  double setPixelsInternal(double newPixels) {
+  double setPixelsInternal(double newPixels, double sourceMaxScrollExtent) {
+    // If we have scroll views of different heights and overscroll, we do not
+    // want that overscroll to be passed on to the peers. So, we make sure to
+    // not scroll beyond the `maxScrollExtent` of the source scroll view.
+    if (newPixels > sourceMaxScrollExtent) {
+      newPixels = sourceMaxScrollExtent;
+    }
     return super.setPixels(newPixels);
   }
 
@@ -345,9 +351,9 @@ class _LinkedScrollActivity extends ScrollActivity {
   @override
   double get velocity => 0.0;
 
-  void moveTo(double newPixels) {
+  void moveTo(double newPixels, sourceMaxScrollExtent) {
     _updateUserScrollDirection();
-    delegate.setPixelsInternal(newPixels);
+    delegate.setPixelsInternal(newPixels, sourceMaxScrollExtent);
   }
 
   void jumpTo(double newPixels) {

--- a/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
+++ b/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
@@ -310,6 +310,25 @@ void main() {
       expect(state._controllers.offset, equals(state._letters.offset));
       expect(state._controllers.offset, equals(state._numbers.offset));
     });
+
+    testWidgets('overscroll does not affect peers', (tester) async {
+      await tester.pumpWidget(TestUnequalListViews());
+      final state = tester
+          .state<TestUnequalListViewsState>(find.byType(TestUnequalListViews));
+
+      expect(state._longer.position.pixels, 0.0);
+      expect(state._shorter.position.pixels, 0.0);
+
+      // Trigger overscroll for the shorter list
+      state._shorter.jumpTo(state._shorter.position.maxScrollExtent + 100);
+
+      await tester.pumpAndSettle();
+
+      expect(state._shorter.position.pixels,
+          state._shorter.position.maxScrollExtent);
+      expect(state._longer.position.pixels,
+          state._shorter.position.maxScrollExtent);
+    });
   });
 }
 
@@ -330,6 +349,64 @@ class TestEmptyGroupState extends State<TestEmptyGroup> {
   @override
   Widget build(BuildContext context) {
     return SizedBox();
+  }
+}
+
+class TestUnequalListViews extends StatefulWidget {
+  @override
+  TestUnequalListViewsState createState() => TestUnequalListViewsState();
+}
+
+class TestUnequalListViewsState extends State<TestUnequalListViews> {
+  late LinkedScrollControllerGroup _controllers;
+  late ScrollController _longer;
+  late ScrollController _shorter;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = LinkedScrollControllerGroup();
+    _longer = _controllers.addAndGet();
+    _shorter = _controllers.addAndGet();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: ListView(
+              controller: _longer,
+              children: <Widget>[
+                Tile('Hello A'),
+                Tile('Hello B'),
+                Tile('Hello C'),
+                Tile('Hello D'),
+                Tile('Hello E'),
+                Tile('Hello F'),
+                Tile('Hello G'),
+                Tile('Hello H'),
+                Tile('Hello I'),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView(
+              controller: _shorter,
+              children: <Widget>[
+                Tile('Hello 1'),
+                Tile('Hello 2'),
+                Tile('Hello 3'),
+                Tile('Hello 4'),
+                Tile('Hello 5'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
+++ b/packages/linked_scroll_controller/test/linked_scroll_controller_test.dart
@@ -319,11 +319,16 @@ void main() {
       expect(state._longer.position.pixels, 0.0);
       expect(state._shorter.position.pixels, 0.0);
 
-      // Trigger overscroll for the shorter list
-      state._shorter.jumpTo(state._shorter.position.maxScrollExtent + 100);
-
+      await tester.dragUntilVisible(find.text('Hello 5'),
+          find.byType(TestUnequalListViews), Offset(0.0, -50.0));
       await tester.pumpAndSettle();
 
+      // Trigger overscroll by scrolling downwards an arbitrary amount
+      await tester.drag(find.text('Hello 5'), Offset(0.0, -300.0));
+      await tester.pumpAndSettle();
+
+      // Verify that the longer list has not continued scrolling after the
+      // shorter list hit `maxScrollExtent`.
       expect(state._shorter.position.pixels,
           state._shorter.position.maxScrollExtent);
       expect(state._longer.position.pixels,


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

<!--
Replace this with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).
-->
When creating multiple lists with unequal heights, triggering the overscroll on a shorter list will not stop longer lists from continuing to scroll. This PR changes this behaviour: when `setPixels` is called with a pixel value above `maxScrollExtent`, we limit that pixel value to `maxScrollExtent`. I've provided a test that shows the bug in the original implementation. I did not implement the change to `forcePixels` because from what I gathered that call should ignore limits such as the `maxScrollExtent`.

## Related Issues

<!--
Replace this with a list of issues related to this PR. Indicate which of these issues are resolved or fixed by this PR.
-->
- #107

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
