### PR TITLE
fix: shadow area clipping is calculated into exposure area accumulation

### DIFF
--- a/packages/visibility_detector/lib/src/visibility_detector_layer.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector_layer.dart
@@ -135,6 +135,8 @@ class VisibilityDetectorLayer extends ContainerLayer {
         curClipRect = parentLayer.clipRRect!.outerRect;
       } else if (parentLayer is ClipPathLayer) {
         curClipRect = parentLayer.clipPath!.getBounds();
+      } else if (parentLayer is PhysicalModelLayer) {
+        curClipRect = parentLayer.clipPath!.getBounds();
       }
 
       if (curClipRect != null) {


### PR DESCRIPTION
It is possible that the business has set a large widget shadow area, and if this is a slideable list, there may be a bias in the exposure calculation.


