### PR TITLE
fix: preventing errors caused by state rebuild

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -247,7 +247,6 @@ class ItemScrollController {
   }
 
   void _attach(_ScrollablePositionedListState scrollableListState) {
-    assert(_scrollableListState == null);
     _scrollableListState = scrollableListState;
   }
 


### PR DESCRIPTION
## Description

This PR solves some corner cases where setState would cause an error of type `'_scrollableListState == null': is not true`

## Related Issues

Similar issue as, but related to the _attach method
https://github.com/google/flutter.widgets/issues/122

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I signed the [CLA].
- [ x] All tests from running `flutter test` pass.
- [ x] `flutter analyze` does not report any problems on my PR.
- [ x] I am willing to follow-up on review comments in a timely manner.

