### PR TITLE
Implement without scrolling when the user insert data before first render item

### DIFF
--- a/packages/scrollable_positioned_list/example/lib/main.dart
+++ b/packages/scrollable_positioned_list/example/lib/main.dart
@@ -6,7 +6,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
-const numberOfItems = 5001;
 const minItemHeight = 20.0;
 const maxItemHeight = 150.0;
 const scrollDuration = Duration(seconds: 2);
@@ -58,9 +57,12 @@ class _ScrollablePositionedListPageState
   /// Listener that reports the position of items when the list is scrolled.
   final ItemPositionsListener itemPositionsListener =
       ItemPositionsListener.create();
+  late List<int> items;
   late List<double> itemHeights;
   late List<Color> itemColors;
+
   bool reversed = false;
+  bool _keepPosition = false;
 
   /// The alignment to be used next time the user scrolls or jumps to an item.
   double alignment = 0;
@@ -68,8 +70,10 @@ class _ScrollablePositionedListPageState
   @override
   void initState() {
     super.initState();
+    const numberOfItems = 5001;
     final heightGenerator = Random(328902348);
     final colorGenerator = Random(42490823);
+    items = List<int>.generate(numberOfItems, (int i) => i);
     itemHeights = List<double>.generate(
         numberOfItems,
         (int _) =>
@@ -96,12 +100,57 @@ class _ScrollablePositionedListPageState
                       const SizedBox(height: 10),
                       jumpControlButtons,
                       alignmentControl,
+                      keepPositionWidget
                     ],
                   ),
                 ],
               )
             ],
           ),
+        ),
+      );
+
+  Widget get keepPositionWidget => SizedBox(
+        height: 40,
+        child: Row(
+          children: [
+            Text("Keep Position"),
+            Checkbox(
+                value: _keepPosition,
+                onChanged: (value) {
+                  this.setState(() {
+                    _keepPosition = value ?? false;
+                  });
+                }),
+            ElevatedButton(
+                onPressed: () {
+                  final heightGenerator = Random(328902348);
+                  final colorGenerator = Random(42490823);
+                  items.insert(0, items[0] - 1);
+                  itemHeights.insert(
+                      0,
+                      heightGenerator.nextDouble() *
+                              (maxItemHeight - minItemHeight) +
+                          minItemHeight);
+                  itemColors.insert(0,
+                      Color(colorGenerator.nextInt(randomMax)).withOpacity(1));
+                  setState(() {});
+                },
+                child: Text("Add to First")),
+            ElevatedButton(
+                onPressed: () {
+                  final heightGenerator = Random(328902348);
+                  final colorGenerator = Random(42490823);
+                  items.add(items.last + 1);
+                  itemHeights.add(heightGenerator.nextDouble() *
+                          (maxItemHeight - minItemHeight) +
+                      minItemHeight);
+                  itemColors.add(
+                      Color(colorGenerator.nextInt(randomMax)).withOpacity(1));
+                  setState(() {});
+                },
+                child: Text("Add to Last"))
+          ],
         ),
       );
 
@@ -126,7 +175,7 @@ class _ScrollablePositionedListPageState
       );
 
   Widget list(Orientation orientation) => ScrollablePositionedList.builder(
-        itemCount: numberOfItems,
+        itemCount: items.length,
         itemBuilder: (context, index) => item(index, orientation),
         itemScrollController: itemScrollController,
         itemPositionsListener: itemPositionsListener,
@@ -134,6 +183,8 @@ class _ScrollablePositionedListPageState
         scrollDirection: orientation == Orientation.portrait
             ? Axis.vertical
             : Axis.horizontal,
+        keepPositionWithoutScroll: _keepPosition,
+        onItemKey: (i) => items[i].toString(),
       );
 
   Widget get positionsView => ValueListenableBuilder<Iterable<ItemPosition>>(
@@ -241,7 +292,7 @@ class _ScrollablePositionedListPageState
       child: Container(
         color: itemColors[i],
         child: Center(
-          child: Text('Item $i'),
+          child: Text('Item ${items[i]}'),
         ),
       ),
     );


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description
Implement without scrolling when the user insert data before first render item
The main idea is adjust the position index.
Notice, The implement only work for vertical scrolling. Not test in horizontal scrolling

<!--
Replace this with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. If you're changing visual properties, consider including before/after screenshots (and runnable code snippets to reproduce them).
-->
*TODO*

## Related Issues

<!--
Replace this with a list of issues related to this PR. Indicate which of these issues are resolved or fixed by this PR.
-->
*TODO*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I signed the [CLA].
- [ ] All tests from running `flutter test` pass.
- [ ] `flutter analyze` does not report any problems on my PR.
- [ ] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
