### PR TITLE
Added ItemScrollController.jumpToPixel and .currentScrollControllerOffset

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -180,8 +180,14 @@ class ScrollablePositionedList extends StatefulWidget {
 class ItemScrollController {
   /// Whether any ScrollablePositionedList objects are attached this object.
   ///
-  /// If `false`, then [jumpTo] and [scrollTo] must not be called.
+  /// If `false`, then [jumpTo], [scrollTo] and [jumpToPixel] must not be called.
   bool get isAttached => _scrollableListState != null;
+
+  /// Returns the current [scrollController.offset].
+  /// Also see [jumpToPixel].
+  double get currentScrollControllerOffset {
+    return _scrollableListState!.primary.scrollController.offset;
+  }
 
   _ScrollablePositionedListState? _scrollableListState;
 
@@ -243,6 +249,13 @@ class ItemScrollController {
       curve: curve,
       opacityAnimationWeights: opacityAnimationWeights,
     );
+  }
+
+  /// Immediately jump the list to the provided [value] via
+  /// [scrollController.jumpTo].
+  /// Also see [currentScrollControllerOffset].
+  void jumpToPixel(double value) {
+    _scrollableListState!.primary.scrollController.jumpTo(value);
   }
 
   void _attach(_ScrollablePositionedListState scrollableListState) {


### PR DESCRIPTION
## Description

Added a method to call `primary.scrollController.jumpTo` and a getter for `primary.scrollController.offset`.
I used the null-safe operator `!` for `_scrollableListState` without checking for null given that is how it is done in other methods and the existence of `isAttached`.

Please note this is my first PR ; be sure to comment about any mistakes I might have made in the process.

## Related Issues

No related issues, this is just something I need that might be useful for others too.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I signed the [CLA].
- [X] All tests from running `flutter test` pass.
- [X] `flutter analyze` does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
