### PR TITLE
Fixed Typo and Made TreeNode children list not final.

### DIFF
--- a/packages/flutter_simple_treeview/lib/src/primitives/key_provider.dart
+++ b/packages/flutter_simple_treeview/lib/src/primitives/key_provider.dart
@@ -22,7 +22,7 @@ class KeyProvider {
       return _TreeNodeKey(_nextIndex++);
     }
     if (_keys.contains(originalKey)) {
-      throw ArgumentError('There should not be nodes with the same kays. '
+      throw ArgumentError('There should not be nodes with the same keys. '
           'Duplicate value found: $originalKey.');
     }
     _keys.add(originalKey);

--- a/packages/flutter_simple_treeview/lib/src/primitives/tree_node.dart
+++ b/packages/flutter_simple_treeview/lib/src/primitives/tree_node.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 
 /// One node of a tree.
 class TreeNode {
-  final List<TreeNode>? children;
+  List<TreeNode>? children;
   final Widget content;
   final Key? key;
 

--- a/packages/flutter_simple_treeview/lib/src/primitives/tree_node.dart
+++ b/packages/flutter_simple_treeview/lib/src/primitives/tree_node.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 
 /// One node of a tree.
 class TreeNode {
-  List<TreeNode>? children;
+  final List<TreeNode>? children;
   final Widget content;
   final Key? key;
 


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

Fixing Typo of an error.
Making TreeNode List not final to be able to modify it.

## Related Issues

Typo Fixed of error when duplicate key value is found in TreeNode.
Making List not final adds more flexibility to it. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
