### PR TITLE
Use the layer tree to do more efficient calculation of transform/clip

### DIFF
--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -212,13 +212,16 @@ mixin RenderVisibilityDetectorBase on RenderObject {
       }
       parent.applyTransform(child, transform);
     }
+
     // Apply whatever transform/clip was on the canvas when painting.
+    if (_lastPaintClipBounds != null) {
+      clip = clip.intersect(MatrixUtils.transformRect(
+        transform,
+        _lastPaintClipBounds!,
+      ));
+    }
     if (_lastPaintTransform != null) {
       transform.multiply(_lastPaintTransform!);
-    }
-
-    if (_lastPaintClipBounds != null) {
-      clip = clip.intersect(_lastPaintClipBounds!);
     }
     return VisibilityInfo.fromRects(
       key: key,

--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -165,7 +165,7 @@ mixin RenderVisibilityDetectorBase on RenderObject {
   }
 
   VisibilityInfo _determineVisibility(ContainerLayer? layer, Rect bounds) {
-    if (_disposed || layer?.attached == false || !attached) {
+    if (_disposed || layer == null || layer.attached == false || !attached) {
       // layer is detached and thus invisible.
       return VisibilityInfo(
         key: key,
@@ -185,10 +185,6 @@ mixin RenderVisibilityDetectorBase on RenderObject {
         child = ancestor;
         ancestor = ancestor.parent! as RenderObject;
       }
-    }
-
-    if (layer == null) {
-      return VisibilityInfo(key: key, size: bounds.size);
     }
 
     // Create a list of Layers from layer to the root, excluding the root

--- a/packages/visibility_detector/test/render_visibility_detector_test.dart
+++ b/packages/visibility_detector/test/render_visibility_detector_test.dart
@@ -4,8 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-// ignore_for_file: invalid_use_of_protected_member
-
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
@@ -31,7 +29,7 @@ void main() {
     detector.paint(context, Offset.zero);
     detector.paint(context, Offset.zero);
 
-    context.stopRecordingIfNeeded();
+    context.stopRecordingIfNeeded(); // ignore: invalid_use_of_protected_member
 
     expect(layer.subtreeHasCompositionCallbacks, true);
 
@@ -78,7 +76,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, true);
 
     expect(detector.debugScheduleUpdateCount, 0);
-    context.stopRecordingIfNeeded();
+    context.stopRecordingIfNeeded(); // ignore: invalid_use_of_protected_member
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 1);
@@ -104,7 +102,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, false);
 
     expect(detector.debugScheduleUpdateCount, 0);
-    context.stopRecordingIfNeeded();
+    context.stopRecordingIfNeeded(); // ignore: invalid_use_of_protected_member
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 0);
@@ -131,7 +129,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, false);
 
     expect(detector.debugScheduleUpdateCount, 0);
-    context.stopRecordingIfNeeded();
+    context.stopRecordingIfNeeded(); // ignore: invalid_use_of_protected_member
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 0);

--- a/packages/visibility_detector/test/render_visibility_detector_test.dart
+++ b/packages/visibility_detector/test/render_visibility_detector_test.dart
@@ -4,10 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+// ignore_for_file: invalid_use_of_protected_member
+
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:visibility_detector/src/render_visibility_detector.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -29,6 +30,9 @@ void main() {
     detector.layout(BoxConstraints.tight(const Size(200, 200)));
     detector.paint(context, Offset.zero);
     detector.paint(context, Offset.zero);
+
+    context.stopRecordingIfNeeded();
+
     expect(layer.subtreeHasCompositionCallbacks, true);
 
     expect(detector.debugScheduleUpdateCount, 0);
@@ -74,6 +78,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, true);
 
     expect(detector.debugScheduleUpdateCount, 0);
+    context.stopRecordingIfNeeded();
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 1);
@@ -99,6 +104,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, false);
 
     expect(detector.debugScheduleUpdateCount, 0);
+    context.stopRecordingIfNeeded();
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 0);
@@ -125,6 +131,7 @@ void main() {
     expect(layer.subtreeHasCompositionCallbacks, false);
 
     expect(detector.debugScheduleUpdateCount, 0);
+    context.stopRecordingIfNeeded();
     layer.buildScene(SceneBuilder()).dispose();
 
     expect(detector.debugScheduleUpdateCount, 0);

--- a/packages/visibility_detector/test/widget_test.dart
+++ b/packages/visibility_detector/test/widget_test.dart
@@ -25,6 +25,73 @@ void main() {
 
   tearDown(_positionToVisibilityInfo.clear);
 
+  testWidgets('Offset coming into paint applied to clip',
+      (WidgetTester tester) async {
+    VisibilityInfo? lastInfo;
+    await tester.pumpWidget(
+      Center(
+        child: SizedBox(
+          height: 400,
+          width: 400,
+          child: Transform(
+            transform: Matrix4.identity()..translate(0.0, -300.0),
+            child: ClipRect(
+              clipBehavior: Clip.hardEdge,
+              child: VisibilityDetector(
+                key: UniqueKey(),
+                onVisibilityChanged: (info) {
+                  lastInfo = info;
+                },
+                child: Container(width: 200, height: 350, color: Colors.red),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(VisibilityDetectorController.instance.updateInterval);
+    expect(lastInfo, isNotNull);
+    expect(lastInfo!.visibleFraction, 1.0);
+    await tester.pumpWidget(const Placeholder());
+    await tester.pump(VisibilityDetectorController.instance.updateInterval);
+  });
+
+  testWidgets('Transform in layer tree, clip on canvas gets transformed',
+      (WidgetTester tester) async {
+    VisibilityInfo? lastInfo;
+    await tester.pumpWidget(
+      Center(
+        child: SizedBox(
+          height: 400,
+          width: 400,
+          child: Transform(
+            transform: Matrix4.identity()
+              ..translate(0.0, -300.0)
+              ..scale(-.9, -.9),
+            child: Opacity(
+              opacity: .8,
+              child: ClipRect(
+                clipBehavior: Clip.hardEdge,
+                child: VisibilityDetector(
+                  key: UniqueKey(),
+                  onVisibilityChanged: (info) {
+                    lastInfo = info;
+                  },
+                  child: Container(width: 200, height: 350, color: Colors.red),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(VisibilityDetectorController.instance.updateInterval);
+    expect(lastInfo, isNotNull);
+    expect(lastInfo!.visibleFraction, 1.0);
+    await tester.pumpWidget(const Placeholder());
+    await tester.pump(VisibilityDetectorController.instance.updateInterval);
+  });
+
   _wrapTest(
     'VisibilityDetector properly builds',
     callback: (tester) async {


### PR DESCRIPTION
Uses new API added in Flutter to get the current transform and clip from the canvas. This allows using the Layer tree, which is generally smaller, when calculating transforms and clips for a render object.

I will test this on TAP before requesting review.