### PR TITLE
Skip an `Element` if its `RenderObject` has never been laid out

### DIFF
--- a/packages/scrollable_positioned_list/CHANGELOG.md
+++ b/packages/scrollable_positioned_list/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.3
+* Fix potential crash when reading from RenderBox.size.
+
 # 0.3.2
 * Re-apply Flutter framework bindings' null safety calls but set SDK
   constraints correctly to 2.12.0 instead.

--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -309,13 +309,14 @@ class _PositionedListState extends State<PositionedList> {
     if (!updateScheduled) {
       updateScheduled = true;
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (registeredElements.value == null) {
+        final elements = registeredElements.value;
+        if (elements == null) {
           updateScheduled = false;
           return;
         }
         final positions = <ItemPosition>[];
         RenderViewportBase? viewport;
-        for (var element in registeredElements.value!) {
+        for (var element in elements) {
           final RenderBox box = element.renderObject as RenderBox;
           viewport ??= RenderAbstractViewport.of(box) as RenderViewportBase?;
           var anchor = 0.0;
@@ -328,6 +329,8 @@ class _PositionedListState extends State<PositionedList> {
           }
 
           final ValueKey<int> key = element.widget.key as ValueKey<int>;
+          // Skip this element if `box` has never been laid out.
+          if (!box.hasSize) continue;
           if (widget.scrollDirection == Axis.vertical) {
             final reveal = viewport!.getOffsetToReveal(box, 0).offset;
             if (!reveal.isFinite) continue;

--- a/packages/scrollable_positioned_list/pubspec.yaml
+++ b/packages/scrollable_positioned_list/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scrollable_positioned_list
-version: 0.3.2
+version: 0.3.3
 description: >
   A list with helper methods to programmatically scroll to an item.
 homepage: https://github.com/google/flutter.widgets/tree/master/packages/scrollable_positioned_list

--- a/packages/scrollable_positioned_list/test/positioned_list_test.dart
+++ b/packages/scrollable_positioned_list/test/positioned_list_test.dart
@@ -360,4 +360,55 @@ void main() {
             .itemTrailingEdge,
         1);
   });
+
+  testWidgets('Does not crash when updated offscreen',
+      (WidgetTester tester) async {
+    late var setState;
+    bool updated = false;
+
+    // There's 0 relayout boundaries in this subtree.
+    final widget = StatefulBuilder(builder: (context, stateSetter) {
+      setState = stateSetter;
+      return Positioned(
+          left: 0,
+          right: 0,
+          child: PositionedList(
+            shrinkWrap: true,
+            itemCount: 1,
+            // When `updated` becomes true this line inserts a
+            // RenderIndexedSemantics to the render tree.
+            addSemanticIndexes: updated,
+            itemBuilder: (context, index) => SizedBox(height: itemHeight),
+          ));
+    });
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Overlay(
+        initialEntries: [
+          OverlayEntry(builder: (context) => widget, maintainState: true),
+        ],
+      ),
+    ));
+
+    // Insert a new opaque OverlayEntry that would prevent the first OverlayEntry
+    // from doing re-layout. Since there's no relayout boundaries in the first
+    // OverlayEntry, no dirty RenderObjects in its render subtree can update
+    // layout.
+    final newOverlay =
+        OverlayEntry(builder: (context) => SizedBox.expand(), opaque: true);
+    tester.state<OverlayState>(find.byType(Overlay)).insert(newOverlay);
+    await tester.pump();
+
+    // Update the list item's render tree. A new RenderObjectElement is
+    // inflated, registeredElement.renderObject will point to this new
+    // RenderObjectElement's RenderObject (RenderIndexedSemantics), which has
+    // never been laid out.
+    setState(() {
+      updated = true;
+    });
+
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION

<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

There're (obscure) cases where a `RegisteredElement` can point to a `RenderObject` that has never been laid out and querying the `RenderObject`'s size crashes the app. See the test for an example.

## Related Issues

Maybe: internal b/183417182 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [ ] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
