### PR TITLE
visibility_detector: Fix analysis issues with Flutter 3.1.0

### DIFF
--- a/packages/visibility_detector/CHANGELOG.md
+++ b/packages/visibility_detector/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.4.0+1
+
+* Correct Flutter SDK version dependency to 3.1.0.
+* Replace use of deprecated APIs in the example for compatibility with Flutter v3.1.0.
+
 ## 0.4.0
 
 * Refactor to avoid forcing composition in the layer/render trees.

--- a/packages/visibility_detector/example/lib/main.dart
+++ b/packages/visibility_detector/example/lib/main.dart
@@ -368,7 +368,10 @@ class DemoPageCell extends StatelessWidget {
       alignment: Alignment.center,
       child: FittedBox(
         fit: BoxFit.scaleDown,
-        child: Text(_cellName, style: Theme.of(context).textTheme.headline4),
+        child: Text(
+          _cellName,
+          style: Theme.of(context).textTheme.headlineMedium,
+        ),
       ),
     );
 
@@ -411,7 +414,7 @@ class VisibilityReport extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final headingTextStyle =
-        Theme.of(context).textTheme.headline6!.copyWith(color: Colors.white);
+        Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.white);
 
     final heading = Container(
       padding: const EdgeInsets.all(_reportPadding),

--- a/packages/visibility_detector/pubspec.yaml
+++ b/packages/visibility_detector/pubspec.yaml
@@ -1,12 +1,12 @@
 name: visibility_detector
-version: 0.4.0
+version: 0.4.0+1
 description: >
   A widget that detects the visibility of its child and notifies a callback.
 repository: https://github.com/google/flutter.widgets/tree/master/packages/visibility_detector
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.12.0'
+  flutter: '>=3.1.0-0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
visibility_detector: Fix analysis issues with Flutter 3.1.0

* Replace deprecated API usage.
* Fix the Flutter SDK version dependency to depend on Flutter 3.1.0.
  Analysis previously failed with Flutter 3.0.5.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
