### PR TITLE
Avoid accessing bounds of widget that has never been laid out

### DIFF
--- a/packages/visibility_detector/CHANGELOG.md
+++ b/packages/visibility_detector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4.0+2
+
+* Fix a bug for updates to render objects that have not been laid out yet.
+
 ## 0.4.0+1
 
 * Correct Flutter SDK version dependency to 3.1.0.

--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -140,7 +140,10 @@ mixin RenderVisibilityDetectorBase on RenderObject {
     }
     bool isFirstUpdate = _updates.isEmpty;
     _updates[key] = () {
-      _fireCallback(layer, bounds);
+      if (bounds == null) {
+        return;
+      }
+      _fireCallback(layer, bounds!);
     };
     final updateInterval = VisibilityDetectorController.instance.updateInterval;
     if (updateInterval == Duration.zero) {
@@ -228,7 +231,9 @@ mixin RenderVisibilityDetectorBase on RenderObject {
 
   /// Used to get the bounds of the render object when it is time to update
   /// clients about visibility.
-  Rect get bounds;
+  ///
+  /// A null value means bounds are not available.
+  Rect? get bounds;
 
   Matrix4? _lastPaintTransform;
   Rect? _lastPaintClipBounds;
@@ -280,7 +285,7 @@ class RenderVisibilityDetector extends RenderProxyBox
   final Key key;
 
   @override
-  Rect get bounds => semanticBounds;
+  Rect? get bounds => hasSize ? semanticBounds : null;
 }
 
 /// The [RenderObject] corresponding to the [SliverVisibilityDetector] widget.
@@ -302,7 +307,11 @@ class RenderSliverVisibilityDetector extends RenderProxySliver
   final Key key;
 
   @override
-  Rect get bounds {
+  Rect? get bounds {
+    if (geometry == null) {
+      return null;
+    }
+
     Size widgetSize;
     Offset widgetOffset;
     switch (applyGrowthDirectionToAxisDirection(

--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -141,6 +141,10 @@ mixin RenderVisibilityDetectorBase on RenderObject {
     bool isFirstUpdate = _updates.isEmpty;
     _updates[key] = () {
       if (bounds == null) {
+        // This can happen if set onVisibilityChanged was called with a non-null
+        // value but this render object has not been laid out. In that case,
+        // it has no size or geometry, and we should not worry about firing
+        // an update since it never has been visible.
         return;
       }
       _fireCallback(layer, bounds!);

--- a/packages/visibility_detector/pubspec.yaml
+++ b/packages/visibility_detector/pubspec.yaml
@@ -1,5 +1,5 @@
 name: visibility_detector
-version: 0.4.0+1
+version: 0.4.0+2
 description: >
   A widget that detects the visibility of its child and notifies a callback.
 repository: https://github.com/google/flutter.widgets/tree/master/packages/visibility_detector

--- a/packages/visibility_detector/test/render_visibility_detector_test.dart
+++ b/packages/visibility_detector/test/render_visibility_detector_test.dart
@@ -139,7 +139,9 @@ void main() {
       (WidgetTester tester) async {
     final RenderVisibilityDetector detector = RenderVisibilityDetector(
       key: Key('test'),
-      onVisibilityChanged: (_) { fail('should not get called'); },
+      onVisibilityChanged: (_) {
+        fail('should not get called');
+      },
     );
 
     // Force an out of band update to get scheduled without laying out.
@@ -152,11 +154,15 @@ void main() {
     detector.dispose();
   });
 
-  testWidgets('RVS (Sliver) can schedule an update for a RO that is not laid out',
+  testWidgets(
+      'RVS (Sliver) can schedule an update for a RO that is not laid out',
       (WidgetTester tester) async {
-    final RenderSliverVisibilityDetector detector = RenderSliverVisibilityDetector(
+    final RenderSliverVisibilityDetector detector =
+        RenderSliverVisibilityDetector(
       key: Key('test'),
-      onVisibilityChanged: (_) { fail('should not get called'); },
+      onVisibilityChanged: (_) {
+        fail('should not get called');
+      },
     );
 
     // Force an out of band update to get scheduled without laying out.

--- a/packages/visibility_detector/test/render_visibility_detector_test.dart
+++ b/packages/visibility_detector/test/render_visibility_detector_test.dart
@@ -151,4 +151,21 @@ void main() {
 
     detector.dispose();
   });
+
+  testWidgets('RVS (Sliver) can schedule an update for a RO that is not laid out',
+      (WidgetTester tester) async {
+    final RenderSliverVisibilityDetector detector = RenderSliverVisibilityDetector(
+      key: Key('test'),
+      onVisibilityChanged: (_) { fail('should not get called'); },
+    );
+
+    // Force an out of band update to get scheduled without laying out.
+    detector.onVisibilityChanged = (_) {
+      fail('This should also not get called');
+    };
+
+    expect(detector.debugScheduleUpdateCount, 1);
+
+    detector.dispose();
+  });
 }

--- a/packages/visibility_detector/test/render_visibility_detector_test.dart
+++ b/packages/visibility_detector/test/render_visibility_detector_test.dart
@@ -134,4 +134,21 @@ void main() {
 
     expect(detector.debugScheduleUpdateCount, 0);
   });
+
+  testWidgets('RVS can schedule an update for a RO that is not laid out',
+      (WidgetTester tester) async {
+    final RenderVisibilityDetector detector = RenderVisibilityDetector(
+      key: Key('test'),
+      onVisibilityChanged: (_) { fail('should not get called'); },
+    );
+
+    // Force an out of band update to get scheduled without laying out.
+    detector.onVisibilityChanged = (_) {
+      fail('This should also not get called');
+    };
+
+    expect(detector.debugScheduleUpdateCount, 1);
+
+    detector.dispose();
+  });
 }


### PR DESCRIPTION
Speculative fix for b/244342335

This would cause the kind of problem they're seeing in release mode. Hard to know if this definitively fixes that bug without a full reproduction, but it definitely fixes a potential bug in this library.