### PR TITLE
Rtl support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google Inc.
 Abhijeeth Padarthi <rkinabhi@gmail.com>
 Alex Li <alexv.525.li@gmail.com>
+Ibrahim Elaradi <ibrahimelaradi@gmail.com>

--- a/packages/flutter_simple_treeview/lib/src/node_widget.dart
+++ b/packages/flutter_simple_treeview/lib/src/node_widget.dart
@@ -67,7 +67,7 @@ class _NodeWidgetState extends State<NodeWidget> {
         ),
         if (_isExpanded && !_isLeaf)
           Padding(
-            padding: EdgeInsets.only(left: widget.indent!),
+            padding: EdgeInsetsDirectional.only(start: widget.indent!),
             child: buildNodes(widget.treeNode.children!, widget.indent,
                 widget.state, widget.iconSize),
           )


### PR DESCRIPTION
## Description
Changed NodeWidget's Padding (responsible for indentation) to use EdgeInsetsDirectional.start instead of EdgeInsets.left to support RTL layouts.

## Related Issues
Had the issue when using the package myself, no reported issues when I looked for them

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
