### PR TITLE
Check for non-finite item offset

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -345,6 +345,7 @@ class _PositionedListState extends State<PositionedList> {
           } else {
             final itemOffset =
                 box.localToGlobal(Offset.zero, ancestor: viewport).dx;
+            if (!itemOffset.isFinite) continue;
             positions.add(ItemPosition(
                 index: key.value,
                 itemLeadingEdge: (widget.reverse


### PR DESCRIPTION

## Description

Check for non-finite itemOffset, similar to what was done for reveal in #259.  

I'm not able to repo the exception myself, and the stacktrace I have is a bit vague, but I suspect itemOffset is not finite, causing an exception in round.  

## Related Issues

b/242206216

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I signed the [CLA].
- [ x] All tests from running `flutter test` pass.
- [ x] `flutter analyze` does not report any problems on my PR. (analysis errors unrelated to this PR)
- [ x ] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
