### PR TITLE
Remove unused material import

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google Inc.
 Abhijeeth Padarthi <rkinabhi@gmail.com>
 Alex Li <alexv.525.li@gmail.com>
+Kyle Turney <turney.kyle@gmail.com>

--- a/packages/scrollable_positioned_list/lib/src/positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/positioned_list.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -327,7 +327,7 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
   @override
   void initState() {
     super.initState();
-    ItemPosition? initialPosition = PageStorage.of(context).readState(context);
+    ItemPosition? initialPosition = PageStorage.of(context)?.readState(context);
     primary.target = initialPosition?.index ?? widget.initialScrollIndex;
     primary.alignment =
         initialPosition?.itemLeadingEdge ?? widget.initialAlignment;
@@ -643,7 +643,7 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
         .where((ItemPosition position) =>
             position.itemLeadingEdge < 1 && position.itemTrailingEdge > 0);
     if (itemPositions.isNotEmpty) {
-      PageStorage.of(context).writeState(
+      PageStorage.of(context)?.writeState(
           context,
           itemPositions.reduce((value, element) =>
               value.itemLeadingEdge < element.itemLeadingEdge


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

This PR removes an uneccessary `import 'package:flutter/material.dart';`.
Our projects do not use material, so it would be great for us if `scrollable_positioned_list` stayed design system agnostic.

I also fixed 2 missing uses of null aware function invocations, without which I could not run tests locally.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I signed the [CLA].
- [X] All tests from running `flutter test` pass.
- [X] `flutter analyze` does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
