### PR TITLE
[scrollable_positioned_list] Add ScrollController to be observed by Scrollbar

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -287,25 +287,36 @@ class ScrollOffsetController {
       {required double offset,
       required Duration duration,
       Curve curve = Curves.linear}) async {
-    final currentPosition =
-        _scrollableListState!.primary.scrollController.offset;
+     final currentPosition =
+        scrollableListState!.primary.scrollController.offset;
     final newPosition = currentPosition + offset;
-    await _scrollableListState!.primary.scrollController.animateTo(
+    await scrollableListState!.primary.scrollController.animateTo(
       newPosition,
       duration: duration,
       curve: curve,
     );
   }
 
-  _ScrollablePositionedListState? _scrollableListState;
+  Future<void> animateScrollAbsolute(
+      {required double offset,
+      required Duration duration,
+      Curve curve = Curves.linear}) async {
+    await scrollableListState!.primary.scrollController.animateTo(
+      offset,
+      duration: duration,
+      curve: curve,
+    );
+  }
 
-  void _attach(_ScrollablePositionedListState scrollableListState) {
-    assert(_scrollableListState == null);
-    _scrollableListState = scrollableListState;
+  _ScrollablePositionedListState? scrollableListState;
+
+  void _attach(_ScrollablePositionedListState _scrollableListState) {
+    assert(scrollableListState == null);
+    scrollableListState = _scrollableListState;
   }
 
   void _detach() {
-    _scrollableListState = null;
+    scrollableListState = null;
   }
 }
 

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -42,6 +42,7 @@ class ScrollablePositionedList extends StatefulWidget {
     required this.itemBuilder,
     Key? key,
     this.itemScrollController,
+    this.scrollController,
     this.shrinkWrap = false,
     ItemPositionsListener? itemPositionsListener,
     this.scrollOffsetController,
@@ -73,6 +74,7 @@ class ScrollablePositionedList extends StatefulWidget {
     Key? key,
     this.shrinkWrap = false,
     this.itemScrollController,
+    this.scrollController,
     ItemPositionsListener? itemPositionsListener,
     this.scrollOffsetController,
     ScrollOffsetListener? scrollOffsetListener,
@@ -93,6 +95,8 @@ class ScrollablePositionedList extends StatefulWidget {
         itemPositionsNotifier = itemPositionsListener as ItemPositionsNotifier?,
         scrollOffsetNotifier = scrollOffsetListener as ScrollOffsetNotifier?,
         super(key: key);
+
+  final ScrollController? scrollController;
 
   /// Number of items the [itemBuilder] can produce.
   final int itemCount;
@@ -405,6 +409,11 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
 
   @override
   Widget build(BuildContext context) {
+    if (widget.scrollController?.positions.isEmpty == true)
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.scrollController?.attach(primary.scrollController.position);
+      });
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final cacheExtent = _cacheExtent(constraints);
@@ -610,6 +619,9 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
     if (mounted) {
       setState(() {
         if (opacity.value >= 0.5) {
+          if (widget.scrollController?.position != null) {
+            widget.scrollController?.detach(widget.scrollController!.position);
+          }
           // Secondary [ListView] is more visible than the primary; make it the
           // new primary.
           var temp = primary;


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description

Hello everyone!
I found that the solution proposed in the following PRs (https://github.com/google/flutter.widgets/pull/305, https://github.com/google/flutter.widgets/pull/445) is incorrect, since when scrolling long lists, primary and secondary _ListDisplayDetails are swapped. Therefore, you need to track both Scrollcontrollers.
Therefore, I propose the following fix: attach position primary ScrollController if positions is empty, and detach when changing ScrollControllers. I checked in my project, everything works correctly.

## Related Issues

https://github.com/google/flutter.widgets/issues/273
https://github.com/google/flutter.widgets/issues/303
https://github.com/google/flutter.widgets/issues/278
https://github.com/google/flutter.widgets/issues/235
https://github.com/google/flutter.widgets/issues/175
https://github.com/google/flutter.widgets/issues/407

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
