### PR TITLE
Extend ScrollOffsetController to current position and scroll without animation

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -279,12 +279,21 @@ class ItemScrollController {
 /// This is an experimental API and is subject to change.
 /// Behavior may be ill-defined in some cases.  Please file bugs.
 class ScrollOffsetController {
-  Future<void> animateScroll(
-      {required double offset,
-      required Duration duration,
-      Curve curve = Curves.linear}) async {
-    final currentPosition =
-        _scrollableListState!.primary.scrollController.offset;
+  _ScrollablePositionedListState? _scrollableListState;
+
+  void _attach(_ScrollablePositionedListState scrollableListState) {
+    assert(_scrollableListState == null);
+    _scrollableListState = scrollableListState;
+  }
+
+  double get currentPosition =>
+      _scrollableListState!.primary.scrollController.offset;
+
+  Future<void> animateScroll({
+    required double offset,
+    required Duration duration,
+    Curve curve = Curves.linear,
+  }) async {
     final newPosition = currentPosition + offset;
     await _scrollableListState!.primary.scrollController.animateTo(
       newPosition,
@@ -293,11 +302,13 @@ class ScrollOffsetController {
     );
   }
 
-  _ScrollablePositionedListState? _scrollableListState;
-
-  void _attach(_ScrollablePositionedListState scrollableListState) {
-    assert(_scrollableListState == null);
-    _scrollableListState = scrollableListState;
+  void moveScroll({
+    required double offset,
+  }) {
+    final newPosition = currentPosition + offset;
+    _scrollableListState!.primary.scrollController.jumpTo(
+      newPosition,
+    );
   }
 
   void _detach() {

--- a/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
+++ b/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
@@ -72,7 +72,7 @@ void main() {
     );
   }
 
-  testWidgets('Programtically scroll down 50 pixels',
+  testWidgets('Programmatically scroll down 50 pixels',
       (WidgetTester tester) async {
     final scrollDistance = 50.0;
 
@@ -84,7 +84,7 @@ void main() {
       initialIndex: 5,
     );
 
-    final originalOffest = tester.getTopLeft(find.text('Item 5')).dy;
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
     unawaited(scrollOffsetController.animateScroll(
       offset: -scrollDistance,
@@ -94,10 +94,10 @@ void main() {
 
     final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
-    expect(newOffset - originalOffest, scrollDistance);
+    expect(newOffset - originalOffset, scrollDistance);
   });
 
-  testWidgets('Programtically scroll left 50 pixels',
+  testWidgets('Programmatically scroll left 50 pixels',
       (WidgetTester tester) async {
     final scrollDistance = 50.0;
 
@@ -110,7 +110,7 @@ void main() {
       scrollDirection: Axis.horizontal,
     );
 
-    final originalOffest = tester.getTopLeft(find.text('Item 5')).dx;
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dx;
 
     unawaited(scrollOffsetController.animateScroll(
       offset: -scrollDistance,
@@ -120,10 +120,10 @@ void main() {
 
     final newOffset = tester.getTopLeft(find.text('Item 5')).dx;
 
-    expect(newOffset - originalOffest, scrollDistance);
+    expect(newOffset - originalOffset, scrollDistance);
   });
 
-  testWidgets('Programtically scroll down 50 pixels, stop half way',
+  testWidgets('Programmatically scroll down 50 pixels, stop half way',
       (WidgetTester tester) async {
     final scrollDistance = 50.0;
 
@@ -135,7 +135,7 @@ void main() {
       initialIndex: 5,
     );
 
-    final originalOffest = tester.getTopLeft(find.text('Item 5')).dy;
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
     unawaited(scrollOffsetController.animateScroll(
       offset: -scrollDistance,
@@ -150,13 +150,13 @@ void main() {
 
     final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
-    expect(newOffset - originalOffest, scrollDistance ~/ 2);
+    expect(newOffset - originalOffset, scrollDistance ~/ 2);
 
     await tester.pumpAndSettle();
   });
 
   testWidgets(
-      'Programtically scroll down 50 pixels, stop half way and go back 12',
+      'Programmatically scroll down 50 pixels, stop half way and go back 12',
       (WidgetTester tester) async {
     final scrollDistance = 50.0;
     final scrollBack = 12.0;
@@ -169,7 +169,7 @@ void main() {
       initialIndex: 5,
     );
 
-    final originalOffest = tester.getTopLeft(find.text('Item 5')).dy;
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
     unawaited(scrollOffsetController.animateScroll(
       offset: -scrollDistance,
@@ -187,13 +187,13 @@ void main() {
 
     final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
 
-    expect(newOffset - originalOffest, (scrollDistance ~/ 2) - scrollBack);
+    expect(newOffset - originalOffset, (scrollDistance ~/ 2) - scrollBack);
 
     await tester.pumpAndSettle();
   });
 
   testWidgets(
-      'Programtically scroll down 50 pixels, stop half way and then programtically scroll to iten 100',
+      'Programmatically scroll down 50 pixels, stop half way and then programmatically scroll to item 100',
       (WidgetTester tester) async {
     final scrollDistance = 50.0;
 
@@ -224,5 +224,50 @@ void main() {
     expect(tester.getTopLeft(find.text('Item 100')).dy, 0);
 
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('Programmatically move down 50 pixels',
+      (WidgetTester tester) async {
+    final scrollDistance = 50.0;
+
+    ScrollOffsetController scrollOffsetController = ScrollOffsetController();
+
+    await setUpWidgetTest(
+      tester,
+      scrollOffsetController: scrollOffsetController,
+      initialIndex: 5,
+    );
+
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dy;
+
+    scrollOffsetController.moveScroll(
+      offset: -scrollDistance,
+    );
+    await tester.pumpAndSettle();
+
+    final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
+
+    expect(newOffset - originalOffset, scrollDistance);
+  });
+
+  testWidgets('Fetch scroll position', (WidgetTester tester) async {
+    final scrollDistance = 100.0;
+
+    ScrollOffsetController scrollOffsetController = ScrollOffsetController();
+
+    await setUpWidgetTest(
+      tester,
+      scrollOffsetController: scrollOffsetController,
+      initialIndex: 5,
+    );
+
+    expect(scrollOffsetController.currentPosition, isZero);
+
+    scrollOffsetController.moveScroll(
+      offset: scrollDistance,
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollOffsetController.currentPosition, equals(scrollDistance));
   });
 }


### PR DESCRIPTION
## Description
This PR extends ScrollOffsetController to additional two functions, get current position of scroll and scroll without animation. This is motivated by my own project which I needed move scroll instead of animate (you can't use Duration.zero on scroll animation) conditionally when position >= some item position. To summarize this PR supports both.

## Related Issues

https://github.com/google/flutter.widgets/issues/41
https://github.com/google/flutter.widgets/issues/151
https://github.com/google/flutter.widgets/issues/293
https://github.com/google/flutter.widgets/issues/415

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I signed the [CLA].
- [X] All tests from running `flutter test` pass.
- [X] `flutter analyze` does not report any problems on my PR.
- [X] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
