### PR TITLE
Allow listening to primary ScrollController

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -351,9 +351,10 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
       if (!_isTransitioning |
           (widget.scrollOffsetNotifier?.recordProgrammaticScrolls ?? false)) {
         widget.scrollOffsetNotifier?.changeController.add(offsetChange);
-      widget.controllerListener?.call(primary.scrollController);
+        widget.controllerListener?.call(primary.scrollController);
+      }
     });
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.controllerListener?.call(primary.scrollController);
     });
   }

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -57,6 +57,7 @@ class ScrollablePositionedList extends StatefulWidget {
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.minCacheExtent,
+    this.controllerListener,
   })  : assert(itemCount != null),
         assert(itemBuilder != null),
         itemPositionsNotifier = itemPositionsListener as ItemPositionsNotifier?,
@@ -87,12 +88,17 @@ class ScrollablePositionedList extends StatefulWidget {
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.minCacheExtent,
+    this.controllerListener,
   })  : assert(itemCount != null),
         assert(itemBuilder != null),
         assert(separatorBuilder != null),
         itemPositionsNotifier = itemPositionsListener as ItemPositionsNotifier?,
         scrollOffsetNotifier = scrollOffsetListener as ScrollOffsetNotifier?,
         super(key: key);
+
+  /// Optional listener for the primary scroll controller.
+  /// Called once after first frame.
+  final void Function(ScrollController controller)? controllerListener;
 
   /// Number of items the [itemBuilder] can produce.
   final int itemCount;
@@ -345,7 +351,10 @@ class _ScrollablePositionedListState extends State<ScrollablePositionedList>
       if (!_isTransitioning |
           (widget.scrollOffsetNotifier?.recordProgrammaticScrolls ?? false)) {
         widget.scrollOffsetNotifier?.changeController.add(offsetChange);
-      }
+      widget.controllerListener?.call(primary.scrollController);
+    });
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      widget.controllerListener?.call(primary.scrollController);
     });
   }
 


### PR DESCRIPTION
Adds an optional callback to `ScrollablePositionedList` that provides access to updates on the primary ScrollController.

This enables reading the `ScrollPosition` of the controller, in my case required for checking whether a list still fully fits on the screen or is scrollable already.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.
