### PR TITLE
[visibility_detector] Fix example for dart 3.0.0

### DIFF
--- a/packages/visibility_detector/example/lib/main.dart
+++ b/packages/visibility_detector/example/lib/main.dart
@@ -517,7 +517,7 @@ class VisibilityReportGridState extends State<VisibilityReportGrid> {
 }
 
 /// A class for storing a [row, column] pair.
-class RowColumn extends Comparable<RowColumn> {
+class RowColumn implements Comparable<RowColumn> {
   RowColumn(this.row, this.column);
 
   final int row;


### PR DESCRIPTION
## Description

Fix the example for visibility_detector, on sdk>3.0.0 projects the word *extends* is not used anymore when implementing interfaces, it's replaced by *implements*.

![Screenshot_20231215_075233](https://github.com/google/flutter.widgets/assets/4956754/9abe09c6-d8f3-4e3f-a44b-c2e4b00412f7)

See https://github.com/dart-lang/sdk/issues/51440#issuecomment-1434850500

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR. (not related to this PR)
`   info • 'renderView' is deprecated and shouldn't be used. Consider using RendererBinding.renderViews instead as the binding may manage multiple RenderViews. This feature was deprecated after
          v3.10.0-12.0.pre • test/widget_test.dart:465:38 • deprecated_member_use`
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
