### PR TITLE
Null check operator fix when items in ScrollablePositionedList are created/deleted dynamically

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -217,7 +217,7 @@ class ItemScrollController {
   /// * 1 aligns the left edge of the item with the right edge of the view.
   /// * 0.5 aligns the left edge of the item with the center of the view.
   void jumpTo({required int index, double alignment = 0}) {
-    _scrollableListState!._jumpTo(index: index, alignment: alignment);
+    _scrollableListState?._jumpTo(index: index, alignment: alignment);
   }
 
   /// Animate the list over [duration] using the given [curve] such that the


### PR DESCRIPTION
This fixes "Unhandled Exception: Null check operator used on a null value" when items in the ScrollablePositionedList are dynamically created or deleted.

## Description

Currently, when items in ScrollablePositionedList are created dynamically(created or deleted), jumpTo has "!" which indicates that the scrollableListState exists, but this is not the case when items inside ScrollablePositionedList are created or deleted dynamically. 

This is a simple fix which replaces "!" to "?"

## Related Issues

Throws and exception(Unhandled Exception: Null check operator used on a null value) each time items for ScrollablePositionedList are created or deleted dynamically.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [ ] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
