### PR TITLE
scrollable_positioned_list: expose position, offset and add jumpToOffset in ScrollOffsetController

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -279,6 +279,9 @@ class ItemScrollController {
 /// This is an experimental API and is subject to change.
 /// Behavior may be ill-defined in some cases.  Please file bugs.
 class ScrollOffsetController {
+
+  ScrollPosition get position => _scrollableListState!.primary.scrollController.position;
+
   Future<void> animateScroll(
       {required double offset,
       required Duration duration,
@@ -291,6 +294,12 @@ class ScrollOffsetController {
       duration: duration,
       curve: curve,
     );
+  }
+
+  void jumpToOffset(double offset){
+    final currentPosition = _scrollableListState!.primary.scrollController.offset;
+    final newPosition = currentPosition + offset;
+    _scrollableListState!.primary.scrollController.jumpTo(newPosition);
   }
 
   _ScrollablePositionedListState? _scrollableListState;

--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -281,6 +281,7 @@ class ItemScrollController {
 class ScrollOffsetController {
 
   ScrollPosition get position => _scrollableListState!.primary.scrollController.position;
+  Offset get offset => _scrollableListState!.primary.scrollController.offset;
 
   Future<void> animateScroll(
       {required double offset,

--- a/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
+++ b/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
@@ -225,4 +225,28 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('Programtically jump down 50 pixels',
+      (WidgetTester tester) async {
+    final scrollDistance = 50.0;
+
+    ScrollOffsetController scrollOffsetController = ScrollOffsetController();
+
+    await setUpWidgetTest(
+      tester,
+      scrollOffsetController: scrollOffsetController,
+      initialIndex: 5,
+    );
+
+    final originalOffest = tester.getTopLeft(find.text('Item 5')).dy;
+
+    scrollOffsetController.jumpToOffset(-scrollDistance);
+    await tester.pumpAndSettle();
+
+    final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
+
+    expect(newOffset - originalOffest, scrollDistance);
+  });
+
+
 }


### PR DESCRIPTION
## Description

Exposes ScrollPosition and offset of the primary Scrollable within ScrollOffsetController. Also adds `jumpToOffset` which is the same as animateScroll but without animation (you cannot set Duration to zero so this is necessary). Exposing position allows us to use `jumpToOffset` as just  `jumpTo` by subtracting the initial offset. Exposing ScrollPosition is useful for it's `drag` method which is similar to animateScroll but can be used with DragUpdateDetails from eg. onVerticalDragStart in a GestureDetector. 


<!--
Replace this with a list of issues related to this PR. Indicate which of these issues are resolved or fixed by this PR.
-->

Fixes https://github.com/google/flutter.widgets/issues/513

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
