### PR TITLE
[visibility_detector] add custom visible bounds

### DIFF
--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -90,6 +90,9 @@ mixin RenderVisibilityDetectorBase on RenderObject {
   /// The key for the corresponding [VisibilityDetector] widget.
   Key get key;
 
+  /// The customVisibleBounds for the corresponding [VisibilityDetector] widget.
+  Rect? get customVisibleBounds;
+
   VoidCallback? _compositionCallbackCanceller;
 
   VisibilityChangedCallback? _onVisibilityChanged;
@@ -208,7 +211,7 @@ mixin RenderVisibilityDetectorBase on RenderObject {
       ancestor = ancestor.parent;
     }
 
-    Rect clip = Rect.largest;
+    var clip = customVisibleBounds ?? Rect.largest;
     for (int index = ancestors.length - 1; index > 0; index -= 1) {
       final parent = ancestors[index];
       final child = ancestors[index - 1];
@@ -283,6 +286,7 @@ class RenderVisibilityDetector extends RenderProxyBox
     RenderBox? child,
     required this.key,
     required VisibilityChangedCallback? onVisibilityChanged,
+    this.customVisibleBounds,
   })  : assert(key != null),
         super(child) {
     _onVisibilityChanged = onVisibilityChanged;
@@ -290,6 +294,9 @@ class RenderVisibilityDetector extends RenderProxyBox
 
   @override
   final Key key;
+
+  @override
+  Rect? visibilityDetectedArea;
 
   @override
   Rect? get bounds => hasSize ? semanticBounds : null;
@@ -306,12 +313,16 @@ class RenderSliverVisibilityDetector extends RenderProxySliver
     RenderSliver? sliver,
     required this.key,
     required VisibilityChangedCallback? onVisibilityChanged,
+    this.customVisibleBounds,
   }) : super(sliver) {
     _onVisibilityChanged = onVisibilityChanged;
   }
 
   @override
   final Key key;
+
+  @override
+  Rect? visibilityDetectedArea;
 
   @override
   Rect? get bounds {

--- a/packages/visibility_detector/lib/src/render_visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/render_visibility_detector.dart
@@ -296,7 +296,7 @@ class RenderVisibilityDetector extends RenderProxyBox
   final Key key;
 
   @override
-  Rect? visibilityDetectedArea;
+  Rect? customVisibleBounds;
 
   @override
   Rect? get bounds => hasSize ? semanticBounds : null;
@@ -322,7 +322,7 @@ class RenderSliverVisibilityDetector extends RenderProxySliver
   final Key key;
 
   @override
-  Rect? visibilityDetectedArea;
+  Rect? customVisibleBounds;
 
   @override
   Rect? get bounds {

--- a/packages/visibility_detector/lib/src/visibility_detector.dart
+++ b/packages/visibility_detector/lib/src/visibility_detector.dart
@@ -31,6 +31,7 @@ class VisibilityDetector extends SingleChildRenderObjectWidget {
     required Key key,
     required Widget child,
     required this.onVisibilityChanged,
+    this.customVisibleBounds,
   })  : assert(key != null),
         assert(child != null),
         super(key: key, child: child);
@@ -38,12 +39,16 @@ class VisibilityDetector extends SingleChildRenderObjectWidget {
   /// The callback to invoke when this widget's visibility changes.
   final VisibilityChangedCallback? onVisibilityChanged;
 
+  /// Custom visible bounds to use for this widget.
+  final Rect? customVisibleBounds;
+
   /// See [RenderObjectWidget.createRenderObject].
   @override
   RenderVisibilityDetector createRenderObject(BuildContext context) {
     return RenderVisibilityDetector(
       key: key!,
       onVisibilityChanged: onVisibilityChanged,
+      customVisibleBounds: customVisibleBounds,
     );
   }
 
@@ -52,7 +57,9 @@ class VisibilityDetector extends SingleChildRenderObjectWidget {
   void updateRenderObject(
       BuildContext context, RenderVisibilityDetector renderObject) {
     assert(renderObject.key == key);
-    renderObject.onVisibilityChanged = onVisibilityChanged;
+    renderObject
+      ..onVisibilityChanged = onVisibilityChanged
+      ..customVisibleBounds = customVisibleBounds;
   }
 }
 
@@ -68,6 +75,7 @@ class SliverVisibilityDetector extends SingleChildRenderObjectWidget {
     required Key key,
     required Widget sliver,
     required this.onVisibilityChanged,
+    this.customVisibleBounds,
   })  : assert(key != null),
         assert(sliver != null),
         super(key: key, child: sliver);
@@ -75,12 +83,16 @@ class SliverVisibilityDetector extends SingleChildRenderObjectWidget {
   /// The callback to invoke when this widget's visibility changes.
   final VisibilityChangedCallback? onVisibilityChanged;
 
+  /// Custom visible bounds to use for this widget.
+  final Rect? customVisibleBounds;
+
   /// See [RenderObjectWidget.createRenderObject].
   @override
   RenderSliverVisibilityDetector createRenderObject(BuildContext context) {
     return RenderSliverVisibilityDetector(
       key: key!,
       onVisibilityChanged: onVisibilityChanged,
+      customVisibleBounds: customVisibleBounds,
     );
   }
 
@@ -89,7 +101,9 @@ class SliverVisibilityDetector extends SingleChildRenderObjectWidget {
   void updateRenderObject(
       BuildContext context, RenderSliverVisibilityDetector renderObject) {
     assert(renderObject.key == key);
-    renderObject.onVisibilityChanged = onVisibilityChanged;
+    renderObject
+      ..onVisibilityChanged = onVisibilityChanged
+      ..customVisibleBounds = customVisibleBounds;
   }
 }
 


### PR DESCRIPTION
<!--
INSTRUCTIONS:

Please read the CONTRIBUTING.md file first.  In particular, changes to code
behavior should include unit tests.
-->

## Description
### Problem
Even though Stack or something is used and visibility_detector is covered with other widgets, `VisibilityInfo.visibleFraction` doesn't consider this situation.

Not only Stack, but something like ↓, visibility_detector doesn't consider BottomNavigationBar and AppBar.
```dart
Scaffold(
      appBar: // AppBar,
      extendBody: true,
      body: VisibilityDetector(),
      bottomNavigationBar: // BottomNavigationBar    
);
```
### Solution
Added customVisibleBounds which is visibility_detector's detection area. 

## Related Issues

- https://github.com/google/flutter.widgets/issues/417
- https://github.com/google/flutter.widgets/issues/440

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
