### PR TITLE
[scrollable_positioned_list] expose ScrollPosition as unstableScrollPosition in ScrollOffsetController

### DIFF
--- a/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
+++ b/packages/scrollable_positioned_list/lib/src/scrollable_positioned_list.dart
@@ -279,6 +279,15 @@ class ItemScrollController {
 /// This is an experimental API and is subject to change.
 /// Behavior may be ill-defined in some cases.  Please file bugs.
 class ScrollOffsetController {
+  /// ScrollPosition of the current ScrollablePositionedList. Values such as
+  /// pixels, maxScrollExtent and jumpTo are not necessarily defined to start
+  /// from the beginning of the list. When itemScrollController.jumpTo is
+  /// called, the list will begin from that index. unstableScrollPosition.jumpTo
+  /// will cause the application to freeze at very large values as it must build
+  /// all the widgets between the starting offset and the ending offset.
+  ScrollPosition get unstableScrollPosition =>
+      _scrollableListState!.primary.scrollController.position;
+
   Future<void> animateScroll(
       {required double offset,
       required Duration duration,

--- a/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
+++ b/packages/scrollable_positioned_list/test/scroll_offset_controller_test.dart
@@ -225,4 +225,30 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('Programtically jump down 50 pixels',
+      (WidgetTester tester) async {
+    final scrollDistance = 50.0;
+
+    ScrollOffsetController scrollOffsetController = ScrollOffsetController();
+
+    await setUpWidgetTest(
+      tester,
+      scrollOffsetController: scrollOffsetController,
+      initialIndex: 5,
+    );
+
+    final originalOffset = tester.getTopLeft(find.text('Item 5')).dy;
+
+    final currentPosition =
+        scrollOffsetController.unstableScrollPosition.pixels;
+    final newPosition = currentPosition - scrollDistance;
+
+    scrollOffsetController.unstableScrollPosition.jumpTo(newPosition);
+    await tester.pumpAndSettle();
+
+    final newOffset = tester.getTopLeft(find.text('Item 5')).dy;
+
+    expect(newOffset - originalOffset, scrollDistance);
+  });
 }


### PR DESCRIPTION
## Description

This PR exposes `_scrollableListState.primary.scrollController.position` as `unstableScrollPosition`. This allows developers to use the `ScrollPosition` of the ScrollablePositionedList to make local jumps eg. jump to 100px from the current index or jump 100px from the current position. The documentation makes clear that position.jumpTo does not work the same way that it does in a ListView. The usage I have in mind for position is the following.

<details open>
<summary>Usage</summary>

```dart

class _SplDemoState extends State<SplDemo> {
  ScrollOffsetController controller = ScrollOffsetController();
  Drag? _drag;
  @override
  Widget build(BuildContext context) {
    return GestureDetector(
      onVerticalDragStart: (DragStartDetails details){
        //do something
        _drag = controller.position.drag(details, (){});
      },
      onVerticalDragUpdate: (DragUpdateDetails details){
        //do something
        _drag?.update(details);
      },
      child: ScrollablePositionedList.builder(
        scrollOffsetController: controller,
          itemCount: 100000,
          itemBuilder: (context, index) => Text('Item $index'),
      ),
    );
  }
}

```

</details>


The methods/fields I personally need from `position` are `drag`, `hold`, `jumpTo` and `pixels`. I feel at that point it makes sense to just expose the ScrollPositon and let developers use it at their own risk. Note that the current method in `ScrollOffsetController`, `animateScroll`, also falls to the same issues around only being relative to the current origin of the list. The 

I am also fine with only exposing `drag`, `hold` and `relativeJumpTo` which would look like this:

```dart

void relativeJumpTo(double offset){
    final currentPosition = _scrollableListState!.primary.scrollController.offset;
    final newPosition = currentPosition + offset;
    _scrollableListState!.primary.scrollController.jumpTo(newPosition);
  }

```

I also made the following widget to manually test the functionality of the `JumpTo` method (as well as the unit test I added)

<details>
<summary>jumpTo test</summary>

```dart

import 'package:flutter/material.dart';
import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';

void main() {
  runApp(const MaterialApp(home: SplTest()));
}

class SplTest extends StatefulWidget {
  const SplTest({super.key});

  @override
  State<SplTest> createState() => _SplTestState();
}

class _SplTestState extends State<SplTest> {
  final ScrollOffsetController scrollOffsetController = ScrollOffsetController();
  final TextEditingController indexController = TextEditingController();
  final TextEditingController jumpToController = TextEditingController();
  final ItemScrollController itemScrollController = ItemScrollController();

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Column(
        children: [
          Expanded(
            child: ScrollablePositionedList.builder(
              itemScrollController: itemScrollController,
              scrollOffsetController: scrollOffsetController,
              itemCount: 100000000,
              itemBuilder: (context, index) => Text('Item $index'),
            ),
          ),
          Row(
            children: [
              Expanded(
                child: TextField(
                  controller: jumpToController,
                  keyboardType: TextInputType.number,
                  decoration: const InputDecoration(
                    border: OutlineInputBorder(),
                    hintText: 'Enter an offset',
                  ),
                ),
              ),
              TextButton(
                  onPressed: (){
                    final value = double.parse(jumpToController.value.text);
                    scrollOffsetController.position.jumpTo(value);
                  },
                  child: const Text("jump to offset")
              )
            ],
          ),
          Row(
            children: [
              Expanded(
                child: TextField(
                  controller: indexController,
                  keyboardType: TextInputType.number,
                  decoration: const InputDecoration(
                    border: OutlineInputBorder(),
                    hintText: 'Enter an index',
                  ),
                ),
              ),
              TextButton(
                  onPressed: (){
                    final value = int.parse(indexController.value.text);
                    itemScrollController.jumpTo(index: value);
                  },
                  child: const Text("jump to index")
              )
            ],
          ),
        ],
      ),
    );
  }
}


```

</details>

I'd like to receive input on this PR and what other options there are to achieve this functionality if exposing the ScrollPosition is not an option. Simply allowing the developer to provide their own `ScrollController` would work as well. If that is better I'm fine with that too.

## Related Issues

https://github.com/google/flutter.widgets/issues/151
https://github.com/google/flutter.widgets/issues/293
https://github.com/google/flutter.widgets/issues/415
https://github.com/google/flutter.widgets/issues/460
https://github.com/google/flutter.widgets/pull/487
https://github.com/google/flutter.widgets/issues/513
https://github.com/google/flutter.widgets/pull/515


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I signed the [CLA].
- [x] All tests from running `flutter test` pass.
- [x] `flutter analyze` does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
